### PR TITLE
Add manifest tool loader

### DIFF
--- a/examples/.agentry.yaml
+++ b/examples/.agentry.yaml
@@ -1,5 +1,11 @@
 openai_key: sk-...
 tools:
   - name: echo
-    description: returns the given text
-    command: "bash -c 'echo $INPUT'"
+    type: builtin
+    description: Repeat a string
+  - name: ping_api
+    http: https://example.com/ping
+    description: POSTs to API
+  - name: local_shell
+    command: echo hello
+    description: Uses shell (optional, advanced)

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -9,6 +9,7 @@ import (
 type ToolManifest struct {
 	Name        string         `yaml:"name"`
 	Description string         `yaml:"description"`
+	Type        string         `yaml:"type,omitempty"`
 	Command     string         `yaml:"command,omitempty"`
 	HTTP        string         `yaml:"http,omitempty"`
 	Args        map[string]any `yaml:"args,omitempty"`

--- a/internal/tool/manifest.go
+++ b/internal/tool/manifest.go
@@ -1,9 +1,14 @@
 package tool
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
 	"os/exec"
+	"runtime"
 
 	"github.com/marcodenic/agentry/internal/config"
 )
@@ -39,14 +44,80 @@ func (r Registry) Use(name string) (Tool, bool) {
 	return t, ok
 }
 
+// ExecFn defines the signature for tool execution functions.
+type ExecFn func(context.Context, map[string]any) (string, error)
+
+// builtinMap holds safe builtin tools keyed by name.
+var builtinMap = map[string]ExecFn{
+	"echo": func(ctx context.Context, args map[string]any) (string, error) {
+		txt, _ := args["text"].(string)
+		return txt, nil
+	},
+}
+
 func FromManifest(m config.ToolManifest) (Tool, error) {
+	// ensure only one of builtin, http or command is specified
+	count := 0
+	if m.Type != "" {
+		count++
+	}
+	if m.HTTP != "" {
+		count++
+	}
+	if m.Command != "" {
+		count++
+	}
+	if count != 1 {
+		return nil, ErrUnknownManifest
+	}
+
+	// Builtin Go tools
+	if m.Type == "builtin" {
+		fn, ok := builtinMap[m.Name]
+		if !ok {
+			return nil, errors.New("unknown builtin tool")
+		}
+		return New(m.Name, m.Description, fn), nil
+	}
+
+	// HTTP tools
+	if m.HTTP != "" {
+		return New(m.Name, m.Description, func(ctx context.Context, args map[string]any) (string, error) {
+			b, err := json.Marshal(args)
+			if err != nil {
+				return "", err
+			}
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, m.HTTP, bytes.NewReader(b))
+			if err != nil {
+				return "", err
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return "", err
+			}
+			defer resp.Body.Close()
+			rb, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return "", err
+			}
+			return string(rb), nil
+		}), nil
+	}
+
+	// Shell command tools (advanced use, may behave differently across OSes)
 	if m.Command != "" {
 		return New(m.Name, m.Description, func(ctx context.Context, args map[string]any) (string, error) {
-			cmd := exec.CommandContext(ctx, "sh", "-c", m.Command)
+			var cmd *exec.Cmd
+			if runtime.GOOS == "windows" {
+				cmd = exec.CommandContext(ctx, "cmd", "/C", m.Command)
+			} else {
+				cmd = exec.CommandContext(ctx, "sh", "-c", m.Command)
+			}
 			out, err := cmd.CombinedOutput()
 			return string(out), err
 		}), nil
 	}
-	// HTTP wrapper left as exercise
+
 	return nil, ErrUnknownManifest
 }

--- a/tests/tool_manifest_test.go
+++ b/tests/tool_manifest_test.go
@@ -1,0 +1,63 @@
+package tests
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/config"
+	"github.com/marcodenic/agentry/internal/tool"
+)
+
+func TestFromManifestBuiltin(t *testing.T) {
+	m := config.ToolManifest{Name: "echo", Description: "", Type: "builtin"}
+	tl, err := tool.FromManifest(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := tl.Execute(context.Background(), map[string]any{"text": "hello"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "hello" {
+		t.Errorf("expected hello, got %s", out)
+	}
+}
+
+func TestFromManifestHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		w.Write(b)
+	}))
+	defer srv.Close()
+	m := config.ToolManifest{Name: "ping", HTTP: srv.URL, Description: ""}
+	tl, err := tool.FromManifest(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := tl.Execute(context.Background(), map[string]any{"x": "y"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "\"x\":\"y\"") {
+		t.Errorf("unexpected http output: %s", out)
+	}
+}
+
+func TestFromManifestCommand(t *testing.T) {
+	m := config.ToolManifest{Name: "local", Command: "echo hi", Description: ""}
+	tl, err := tool.FromManifest(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := tl.Execute(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(out) != "hi" {
+		t.Errorf("expected hi, got %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- support builtins, HTTP and shell commands from tool manifest
- add builtin `echo`
- extend config schema with `type`
- update example `.agentry.yaml`
- add tests for manifest tool loading

## Testing
- `go test ./...`
- `npm install && npm test` (tests passed but required manual exit)


------
https://chatgpt.com/codex/tasks/task_e_684d874ee0748320a7773a558ed79f34