### PR TITLE
Improve env loading

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -2,13 +2,27 @@ package env
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/joho/godotenv"
 )
 
 // Load loads variables from .env.local if the file exists.
 func Load() {
-	if _, err := os.Stat(".env.local"); err == nil {
-		_ = godotenv.Load(".env.local")
+	dir, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	for {
+		path := filepath.Join(dir, ".env.local")
+		if _, err := os.Stat(path); err == nil {
+			_ = godotenv.Load(path)
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
 	}
 }


### PR DESCRIPTION
## Summary
- search parent directories for `.env.local` so `OPENAI_KEY` loads even when running in subfolders

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ddb85d5cc8320b311090f404c54d8