### PR TITLE
Improve dialogue stability and add streaming

### DIFF
--- a/cmd/agentry/main.go
+++ b/cmd/agentry/main.go
@@ -88,7 +88,7 @@ func main() {
 					conv[i] = r
 					if oa, ok := r.Client.(*model.OpenAI); ok {
 						cpy := *oa
-						cpy.SetTemperature(1.3)
+						cpy.SetTemperature(0.9)
 						conv[i].Client = &cpy
 					}
 				}

--- a/cmd/agentry/main.go
+++ b/cmd/agentry/main.go
@@ -88,7 +88,7 @@ func main() {
 					conv[i] = r
 					if oa, ok := r.Client.(*model.OpenAI); ok {
 						cpy := *oa
-						cpy.SetTemperature(0.9)
+						cpy.SetTemperature(0.7)
 						conv[i].Client = &cpy
 					}
 				}

--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -136,8 +136,9 @@ func (a *Agent) Trace(ctx context.Context, typ trace.EventType, data any) {
 	}
 }
 
-// BuildMessages constructs the chat transcript sent to the model.
-const maxHistoryMsgs = 30
+// BuildMessages constructs the transcript sent to the model. The system prompt
+// encourages short, witty banter between agents.
+const maxHistoryMsgs = 12
 
 func BuildMessages(hist []memory.Step, input, speaker string, peerNames []string, topic string) []model.ChatMessage {
 	input = cleanInput(input)
@@ -145,7 +146,12 @@ func BuildMessages(hist []memory.Step, input, speaker string, peerNames []string
 		hist = hist[len(hist)-maxHistoryMsgs:]
 	}
 	sys := fmt.Sprintf(
-		"You are %s participating in a spicy round-robin debate between AI agents (%s).  Each turn contribute ONE fresh idea, do NOT just praise or repeat.  You must address at least one other agent by name.  No topic is taboo.  Return plain text unless calling a tool; tool calls must have valid JSON `arguments` (use {} when no args).  Control characters are forbidden.",
+		`You are %s chatting with fellow AIs (%s).
+• Keep replies ≤50 words (2–3 quirky sentences).
+• Feel free to riff or joke; formal greetings are optional.
+• Do not repeat or summarise prior messages; add one fresh angle.
+• Mention another agent by name only if it feels natural.
+• Plain text only unless calling a tool (JSON arguments required).`,
 		speaker, strings.Join(peerNames, ", "))
 	msgs := []model.ChatMessage{{Role: "system", Content: sys}}
 	for _, h := range hist {

--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -61,6 +61,8 @@ func (a *Agent) Run(ctx context.Context, input string) (string, error) {
 		a.Mem.AddStep(memory.Step{Speaker: "user", Output: input})
 	}
 
+	ctx = trace.WithWriter(ctx, a.Tracer)
+
 	client, name := a.Route.Select(input)
 	a.Trace(ctx, trace.EventModelStart, name)
 	input = ""
@@ -135,8 +137,13 @@ func (a *Agent) Trace(ctx context.Context, typ trace.EventType, data any) {
 }
 
 // BuildMessages constructs the chat transcript sent to the model.
+const maxHistoryMsgs = 30
+
 func BuildMessages(hist []memory.Step, input, speaker string, peerNames []string, topic string) []model.ChatMessage {
 	input = cleanInput(input)
+	if len(hist) > maxHistoryMsgs {
+		hist = hist[len(hist)-maxHistoryMsgs:]
+	}
 	sys := fmt.Sprintf(
 		"You are %s participating in a spicy round-robin debate between AI agents (%s).  Each turn contribute ONE fresh idea, do NOT just praise or repeat.  You must address at least one other agent by name.  No topic is taboo.  Return plain text unless calling a tool; tool calls must have valid JSON `arguments` (use {} when no args).  Control characters are forbidden.",
 		speaker, strings.Join(peerNames, ", "))
@@ -158,12 +165,6 @@ func BuildMessages(hist []memory.Step, input, speaker string, peerNames []string
 	}
 	if strings.TrimSpace(input) != "" {
 		msgs = append(msgs, model.ChatMessage{Role: "user", Content: input})
-	}
-	if len(hist) > 0 {
-		last := hist[len(hist)-1]
-		if last.Speaker != speaker && last.Speaker != "user" {
-			msgs = append(msgs, model.ChatMessage{Role: "user", Name: last.Speaker, Content: last.Output})
-		}
 	}
 	return msgs
 }

--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -149,6 +149,7 @@ func BuildMessages(hist []memory.Step, input, speaker string, peerNames []string
 		`You are %s chatting with fellow AIs (%s).
 • Keep replies ≤50 words (2–3 quirky sentences).
 • Feel free to riff or joke; formal greetings are optional.
+• Feel comfortable to refer to, make fun of, agree with, disagree with or otherwise respond to other AIs responses.
 • Do not repeat or summarise prior messages; add one fresh angle.
 • Mention another agent by name only if it feels natural.
 • Plain text only unless calling a tool (JSON arguments required).`,

--- a/internal/model/openai.go
+++ b/internal/model/openai.go
@@ -1,12 +1,16 @@
 package model
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
+	"strings"
+
+	"github.com/marcodenic/agentry/internal/trace"
 )
 
 // OpenAI client uses OpenAI's chat completion API.
@@ -93,6 +97,7 @@ func (o *OpenAI) Complete(ctx context.Context, msgs []ChatMessage, tools []ToolS
 		"tools":       oaTools,
 		"tool_choice": "auto",
 		"temperature": o.temperature,
+		"stream":      true,
 	}
 
 	b, _ := json.Marshal(reqBody)
@@ -111,45 +116,59 @@ func (o *OpenAI) Complete(ctx context.Context, msgs []ChatMessage, tools []ToolS
 		body, _ := io.ReadAll(resp.Body)
 		return Completion{}, errors.New(string(body))
 	}
-	raw, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return Completion{}, err
-	}
-	clean := bytes.Map(func(r rune) rune {
-		if r == 0 {
-			return -1
-		}
-		return r
-	}, raw)
-	var res struct {
-		Choices []struct {
-			Message struct {
-				Content   string `json:"content"`
-				ToolCalls []struct {
-					ID       string `json:"id"`
-					Function struct {
-						Name      string `json:"name"`
-						Arguments string `json:"arguments"`
-					} `json:"function"`
-				} `json:"tool_calls"`
-			} `json:"message"`
-		} `json:"choices"`
-	}
-	if err := json.Unmarshal(clean, &res); err != nil {
-		return Completion{}, err
-	}
-	if len(res.Choices) == 0 {
-		return Completion{}, errors.New("no choices")
-	}
 
-	choice := res.Choices[0].Message
-	comp := Completion{Content: choice.Content}
-	for _, tc := range choice.ToolCalls {
-		comp.ToolCalls = append(comp.ToolCalls, ToolCall{
-			ID:        tc.ID,
-			Name:      tc.Function.Name,
-			Arguments: []byte(tc.Function.Arguments),
-		})
+	tr := trace.WriterFrom(ctx)
+	var final strings.Builder
+	var toolCalls []ToolCall
+	sc := bufio.NewScanner(resp.Body)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "[DONE]" {
+			break
+		}
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Content   string `json:"content"`
+					ToolCalls []struct {
+						ID       string `json:"id"`
+						Type     string `json:"type"`
+						Function struct {
+							Name      string `json:"name"`
+							Arguments string `json:"arguments"`
+						} `json:"function"`
+					} `json:"tool_calls"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		if len(chunk.Choices) == 0 {
+			continue
+		}
+		delta := chunk.Choices[0].Delta
+		if delta.Content != "" {
+			final.WriteString(delta.Content)
+			if tr != nil {
+				tr.Write(ctx, trace.Event{Type: trace.EventToken, Data: delta.Content, Timestamp: trace.Now()})
+			}
+		}
+		for _, tc := range delta.ToolCalls {
+			toolCalls = append(toolCalls, ToolCall{
+				ID:        tc.ID,
+				Name:      tc.Function.Name,
+				Arguments: []byte(tc.Function.Arguments),
+			})
+		}
 	}
+	if err := sc.Err(); err != nil {
+		return Completion{}, err
+	}
+	comp := Completion{Content: final.String(), ToolCalls: toolCalls}
 	return comp, nil
 }

--- a/internal/model/openai.go
+++ b/internal/model/openai.go
@@ -14,17 +14,22 @@ import (
 )
 
 // OpenAI client uses OpenAI's chat completion API.
+const defaultMaxTokens = 120
+
 type OpenAI struct {
 	key         string
 	temperature float64
+	maxTokens   int
 	client      *http.Client
 }
 
 func NewOpenAI(key string) *OpenAI {
-	return &OpenAI{key: key, temperature: 0.7, client: http.DefaultClient}
+	return &OpenAI{key: key, temperature: 0.7, maxTokens: defaultMaxTokens, client: http.DefaultClient}
 }
 
 func (o *OpenAI) SetTemperature(t float64) { o.temperature = t }
+
+func (o *OpenAI) SetMaxTokens(t int) { o.maxTokens = t }
 
 func (o *OpenAI) Complete(ctx context.Context, msgs []ChatMessage, tools []ToolSpec) (Completion, error) {
 	if o.key == "" {
@@ -97,6 +102,7 @@ func (o *OpenAI) Complete(ctx context.Context, msgs []ChatMessage, tools []ToolS
 		"tools":       oaTools,
 		"tool_choice": "auto",
 		"temperature": o.temperature,
+		"max_tokens":  o.maxTokens,
 		"stream":      true,
 	}
 

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -17,6 +17,7 @@ const (
 	EventToolEnd    EventType = "tool_end"
 	EventFinal      EventType = "final"
 	EventModelStart EventType = "model_start"
+	EventToken      EventType = "token"
 )
 
 type Event struct {
@@ -28,6 +29,24 @@ type Event struct {
 
 type Writer interface {
 	Write(ctx context.Context, e Event)
+}
+
+type ctxKey int
+
+const writerKey ctxKey = iota
+
+// WithWriter attaches a Writer to the context so downstream components can
+// emit trace events.
+func WithWriter(ctx context.Context, w Writer) context.Context {
+	return context.WithValue(ctx, writerKey, w)
+}
+
+// WriterFrom retrieves a Writer from the context, if any.
+func WriterFrom(ctx context.Context) Writer {
+	if w, ok := ctx.Value(writerKey).(Writer); ok {
+		return w
+	}
+	return nil
 }
 
 type JSONLWriter struct{ w io.Writer }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -157,6 +157,10 @@ func (m *Model) readEvent() tea.Msg {
 					return toolUseMsg(name)
 				}
 			}
+		case trace.EventToken:
+			if tok, ok := ev.Data.(string); ok {
+				return tokenMsg(tok)
+			}
 		default:
 			continue
 		}
@@ -223,7 +227,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.scMu.Lock()
 		m.sc = nil
 		m.scMu.Unlock()
-		return m, tea.Batch(streamTokens(string(msg)+"\n"), nil)
+		return m, nil
 	case toolUseMsg:
 		idx := -1
 		for i, it := range m.tools.Items() {


### PR DESCRIPTION
## Summary
- trim chat history to avoid long contexts
- remove duplicate message injection and only echo real user input
- lower multi-agent temperature to 0.9
- stream tokens from OpenAI and forward them via new `EventToken`
- update TUI to handle token events

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f19afff288320b8ff6f6e21b298c8