### PR TITLE
Fix streaming TUI assistant layout

### DIFF
--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -19,3 +19,16 @@ func TestNew(t *testing.T) {
 		t.Fatalf("expected no tools")
 	}
 }
+
+func TestAssistantBarOnFirstToken(t *testing.T) {
+	ag := core.New(router.Rules{{IfContains: []string{""}, Client: nil}}, tool.Registry{}, memory.NewInMemory(), nil)
+	m := New(ag)
+	m.history = userBar() + " hi\n"
+	m.awaitingAssistant = true
+	nm, _ := m.Update(tokenMsg("H"))
+	m = nm.(Model)
+	exp := userBar() + " hi\n" + aiBar() + " H"
+	if m.history != exp {
+		t.Fatalf("expected %q got %q", exp, m.history)
+	}
+}


### PR DESCRIPTION
## Summary
- restore assistant bar placement when streaming tokens
- only enable short multi-agent prompt in `converse`
- test the assistant bar behaviour

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f578647ac8320b8fa59167d078c98