### PR TITLE
Reintroduce streaming output for converse REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ npm --prefix ts-sdk run build
 node -e "const {invoke}=require('./ts-sdk/dist');invoke('hi',{stream:false}).then(console.log)"
 ```
 
+### Dev REPL tricks
+
+#### Multi-agent conversations
+
+The `converse` command spawns multiple sub-agents that riff off one another. This feature is for the dev REPL only and is not available in the TUI.
+
+```bash
+converse 3 Is God real?
+```
+
+The first number selects how many agents join the chat. Any remaining text becomes the opening message. If omitted, a generic greeting is used.
+
 ## Environment Configuration
 
 Copy `.env.example` to `.env.local` and fill in `OPENAI_KEY` to enable real OpenAI calls. The file is loaded automatically on startup and during tests.

--- a/internal/converse/prompt.go
+++ b/internal/converse/prompt.go
@@ -1,0 +1,58 @@
+package converse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/model"
+)
+
+var colours = []string{
+	"\033[38;5;81m",
+	"\033[38;5;118m",
+	"\033[38;5;214m",
+	"\033[38;5;135m",
+	"\033[38;5;203m",
+}
+
+const colourReset = "\033[0m"
+
+func colourFor(i int) string { return colours[i%len(colours)] }
+
+func cleanInput(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 && r != '\n' && r != '\t' && r != '\r' {
+			return -1
+		}
+		return r
+	}, s)
+}
+
+const maxHistoryMsgs = 12
+
+func BuildMessages(hist []memory.Step, input, speaker string, peers []string) []model.ChatMessage {
+	input = cleanInput(input)
+	if len(hist) > maxHistoryMsgs {
+		hist = hist[len(hist)-maxHistoryMsgs:]
+	}
+	sys := fmt.Sprintf(`You are %s chatting with fellow AIs (%s).
+• Keep replies ≤50 words (2–3 quirky sentences).
+• Feel free to riff or joke; formal greetings are optional.
+• Feel comfortable to refer to, make fun of, agree with, disagree with or otherwise respond to other AIs responses.
+• Do not repeat or summarise prior messages; add one fresh angle.
+• Mention another agent by name only if it feels natural.
+• Plain text only unless calling a tool (JSON arguments required).`,
+		speaker, strings.Join(peers, ", "))
+	msgs := []model.ChatMessage{{Role: "system", Content: sys}}
+	for _, h := range hist {
+		msgs = append(msgs, model.ChatMessage{Role: "assistant", Content: h.Output, ToolCalls: h.ToolCalls})
+		for id, res := range h.ToolResults {
+			msgs = append(msgs, model.ChatMessage{Role: "tool", ToolCallID: id, Content: res})
+		}
+	}
+	if strings.TrimSpace(input) != "" {
+		msgs = append(msgs, model.ChatMessage{Role: "user", Content: input})
+	}
+	return msgs
+}

--- a/internal/converse/runner.go
+++ b/internal/converse/runner.go
@@ -1,0 +1,136 @@
+package converse
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/model"
+	"github.com/marcodenic/agentry/internal/router"
+	"github.com/marcodenic/agentry/internal/tool"
+)
+
+const maxTurns = 10
+
+// Run spawns n sub-agents from parent and lets them talk about the given topic.
+// The returned slice contains each message in order.
+func Run(ctx context.Context, parent *core.Agent, n int, topic string) ([]string, error) {
+	return runLoop(ctx, parent, n, topic, nil)
+}
+
+func runLoop(ctx context.Context, parent *core.Agent, n int, topic string, cb func(turn int, out string)) ([]string, error) {
+	if n <= 0 {
+		return nil, fmt.Errorf("n must be > 0")
+	}
+
+	if topic == "" {
+		topic = "Hello agents, let's chat!"
+	} else if (strings.HasPrefix(topic, "\"") && strings.HasSuffix(topic, "\"")) ||
+		(strings.HasPrefix(topic, "'") && strings.HasSuffix(topic, "'")) {
+		topic = strings.Trim(topic, "'\"")
+	}
+
+	shared := memory.NewInMemory()
+
+	// Copy router rules to bump temperature
+	convRoute := parent.Route
+	if rules, ok := parent.Route.(router.Rules); ok {
+		cpy := make(router.Rules, len(rules))
+		for i, r := range rules {
+			cpy[i] = r
+			cpy[i].Client = model.WithTemperature(r.Client, 0.7)
+		}
+		convRoute = cpy
+	}
+
+	agents := make([]*core.Agent, n)
+	names := make([]string, n)
+	for i := 0; i < n; i++ {
+		ag := parent.Spawn()
+		ag.Tracer = nil
+		ag.Mem = shared
+		ag.Route = convRoute
+		agents[i] = ag
+		names[i] = fmt.Sprintf("Agent%d", i+1)
+	}
+
+	transcript := make([]string, 0, maxTurns)
+	msg := topic
+	for turn := 0; turn < maxTurns; turn++ {
+		idx := turn % n
+		out, err := runAgent(ctx, agents[idx], msg, names[idx], names)
+		if err != nil {
+			return transcript, err
+		}
+		if cb != nil {
+			cb(turn, out)
+		}
+		transcript = append(transcript, out)
+		msg = out
+	}
+	return transcript, nil
+}
+
+// Repl runs Run() and prints coloured output.
+func Repl(parent *core.Agent, n int, topic string) {
+	_, err := runLoop(context.Background(), parent, n, topic, func(turn int, out string) {
+		idx := turn % n
+		col := colourFor(idx)
+		fmt.Printf("%s[Agent%d]%s: %s\n", col, idx+1, colourReset, out)
+	})
+	if err != nil {
+		fmt.Println("ERR:", err)
+	}
+}
+
+func runAgent(ctx context.Context, ag *core.Agent, input, name string, peers []string) (string, error) {
+	client, _ := ag.Route.Select(input)
+	msgs := BuildMessages(ag.Mem.History(), input, name, peers)
+	specs := buildToolSpecs(ag.Tools)
+	for i := 0; i < 8; i++ {
+		res, err := client.Complete(ctx, msgs, specs)
+		if err != nil {
+			return "", err
+		}
+		msgs = append(msgs, model.ChatMessage{Role: "assistant", Content: res.Content, ToolCalls: res.ToolCalls})
+		step := memory.Step{Output: res.Content, ToolCalls: res.ToolCalls, ToolResults: map[string]string{}}
+		if len(res.ToolCalls) == 0 {
+			ag.Mem.AddStep(step)
+			return res.Content, nil
+		}
+		for _, tc := range res.ToolCalls {
+			t, ok := ag.Tools.Use(tc.Name)
+			if !ok {
+				return "", fmt.Errorf("unknown tool: %s", tc.Name)
+			}
+			var args map[string]any
+			if err := json.Unmarshal(tc.Arguments, &args); err != nil {
+				return "", err
+			}
+			r, err := t.Execute(ctx, args)
+			if err != nil {
+				return "", err
+			}
+			step.ToolResults[tc.ID] = r
+			msgs = append(msgs, model.ChatMessage{Role: "tool", ToolCallID: tc.ID, Content: r})
+		}
+		ag.Mem.AddStep(step)
+	}
+	return "", errors.New("max iterations")
+}
+
+func buildToolSpecs(reg tool.Registry) []model.ToolSpec {
+	specs := make([]model.ToolSpec, 0, len(reg))
+	for _, t := range reg {
+		specs = append(specs, model.ToolSpec{
+			Name:        t.Name(),
+			Description: t.Description(),
+			Parameters:  t.JSONSchema(),
+		})
+	}
+	return specs
+}

--- a/internal/model/openai.go
+++ b/internal/model/openai.go
@@ -11,8 +11,9 @@ import (
 
 // OpenAI client uses OpenAI's chat completion API.
 type OpenAI struct {
-	key    string
-	client *http.Client
+	key         string
+	Temperature float64
+	client      *http.Client
 }
 
 func NewOpenAI(key string) *OpenAI {
@@ -89,7 +90,7 @@ func (o *OpenAI) Complete(ctx context.Context, msgs []ChatMessage, tools []ToolS
 		"messages":    oaMsgs,
 		"tools":       oaTools,
 		"tool_choice": "auto",
-		"temperature": 0,
+		"temperature": o.Temperature,
 	}
 
 	b, _ := json.Marshal(reqBody)

--- a/internal/model/temp.go
+++ b/internal/model/temp.go
@@ -1,0 +1,11 @@
+package model
+
+// WithTemperature returns a copy of client with the given temperature if it is an OpenAI client.
+func WithTemperature(c Client, t float64) Client {
+	if oa, ok := c.(*OpenAI); ok {
+		cp := *oa
+		cp.Temperature = t
+		return &cp
+	}
+	return c
+}

--- a/tests/converse_test.go
+++ b/tests/converse_test.go
@@ -1,0 +1,40 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/converse"
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/model"
+	"github.com/marcodenic/agentry/internal/router"
+)
+
+type seqMock struct{ n int }
+
+func (m *seqMock) Complete(ctx context.Context, msgs []model.ChatMessage, tools []model.ToolSpec) (model.Completion, error) {
+	m.n++
+	return model.Completion{Content: fmt.Sprintf("msg%d", m.n)}, nil
+}
+
+func TestConverseRunner(t *testing.T) {
+	mock := &seqMock{}
+	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: mock}}
+	parent := core.New(route, nil, memory.NewInMemory(), nil)
+
+	out, err := converse.Run(context.Background(), parent, 3, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 10 {
+		t.Fatalf("expected 10 turns, got %d", len(out))
+	}
+	for i, msg := range out {
+		exp := fmt.Sprintf("msg%d", i+1)
+		if msg != exp {
+			t.Fatalf("turn %d want %s got %s", i, exp, msg)
+		}
+	}
+}

--- a/tests/multi_agent_role_test.go
+++ b/tests/multi_agent_role_test.go
@@ -3,18 +3,14 @@ package tests
 import (
 	"testing"
 
-	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/converse"
 	"github.com/marcodenic/agentry/internal/memory"
-	"github.com/marcodenic/agentry/internal/router"
 )
 
 func TestRolesStayAssistant(t *testing.T) {
 	mem := memory.NewInMemory()
-	rules := router.Rules{{IfContains: []string{""}}}
-	ag := core.NewNamed("Agent1", rules, nil, mem, nil)
-	ag.PeerNames = []string{"Agent1", "Agent2"}
-	mem.AddStep(memory.Step{Speaker: "Agent2", Output: "hi"})
-	msgs := core.BuildMessages(mem.History(), "", "Agent1", ag.PeerNames, "")
+	mem.AddStep(memory.Step{Output: "hi"})
+	msgs := converse.BuildMessages(mem.History(), "", "Agent1", []string{"Agent1", "Agent2"})
 	if len(msgs) < 2 {
 		t.Fatalf("expected at least two messages")
 	}


### PR DESCRIPTION
## Summary
- reuse run loop with callback to print each agent message immediately
- keep `Run` API for tests but expose streaming via internal callback
- document multi-agent REPL usage in README

## Testing
- `go vet ./...`
- `go test ./...`
- `cd ts-sdk && npm install && npm test`
- `make dev` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_684f83a16ba88320a4270cdcef129992