### PR TITLE
Standardize Go version to 1.23

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ test:
 run: - go test ./... - cd ts-sdk && npm install && npm test
 
 tools:
-go: "1.22"
+go: "1.23"
 node: "22"
 
 filetypes:


### PR DESCRIPTION
## Summary
- update project tooling to use Go 1.23

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852aae9b8248320a3b813d55b250e14