### PR TITLE
Add model/key options for OpenAI model

### DIFF
--- a/examples/.agentry.yaml
+++ b/examples/.agentry.yaml
@@ -4,7 +4,10 @@ models:
   - name: openai
     provider: openai
     options:
-      env_key: OPENAI_KEY
+      # API key; defaults to $OPENAI_KEY if omitted
+      key: ""
+      # Model name; defaults to gpt-4o if omitted
+      model: gpt-4o
 routes:
   - if_contains: [""]
     model: openai

--- a/internal/model/factory.go
+++ b/internal/model/factory.go
@@ -13,13 +13,15 @@ func FromManifest(m config.ModelManifest) (Client, error) {
 	case "mock":
 		return NewMock(), nil
 	case "openai":
-		key := ""
-		if envVar, ok := m.Options["env_key"]; ok && envVar != "" {
-			key = os.Getenv(envVar)
-		} else {
+		key := m.Options["key"]
+		if key == "" {
 			key = os.Getenv("OPENAI_KEY")
 		}
-		return NewOpenAI(key), nil
+		modelName := m.Options["model"]
+		if modelName == "" {
+			modelName = "gpt-4o"
+		}
+		return NewOpenAI(key, modelName), nil
 	default:
 		return nil, fmt.Errorf("unknown provider: %s", m.Provider)
 	}

--- a/internal/model/openai.go
+++ b/internal/model/openai.go
@@ -12,12 +12,13 @@ import (
 // OpenAI client uses OpenAI's chat completion API.
 type OpenAI struct {
 	key         string
+	model       string
 	Temperature float64
 	client      *http.Client
 }
 
-func NewOpenAI(key string) *OpenAI {
-	return &OpenAI{key: key, client: http.DefaultClient}
+func NewOpenAI(key, model string) *OpenAI {
+	return &OpenAI{key: key, model: model, client: http.DefaultClient}
 }
 
 func (o *OpenAI) Complete(ctx context.Context, msgs []ChatMessage, tools []ToolSpec) (Completion, error) {
@@ -86,7 +87,7 @@ func (o *OpenAI) Complete(ctx context.Context, msgs []ChatMessage, tools []ToolS
 	}
 
 	reqBody := map[string]any{
-		"model":       "gpt-4o",
+		"model":       o.model,
 		"messages":    oaMsgs,
 		"tools":       oaTools,
 		"tool_choice": "auto",

--- a/tests/openai_integration_test.go
+++ b/tests/openai_integration_test.go
@@ -13,7 +13,7 @@ func TestOpenAIClient(t *testing.T) {
 	if key == "" {
 		t.Skip("OPENAI_KEY not set")
 	}
-	c := model.NewOpenAI(key)
+	c := model.NewOpenAI(key, "gpt-4o")
 	msgs := []model.ChatMessage{{Role: "user", Content: "Hello"}}
 	comp, err := c.Complete(context.Background(), msgs, nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- allow OpenAI model selection via options
- parse `options.model` and `options.key` when creating OpenAI clients
- document new fields in example config

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852aaeeb1608320be46fec62a62d81c