### PR TITLE
Introduce shared tool spec helper

### DIFF
--- a/internal/converse/runner.go
+++ b/internal/converse/runner.go
@@ -90,7 +90,7 @@ func Repl(parent *core.Agent, n int, topic string) {
 func runAgent(ctx context.Context, ag *core.Agent, input, name string, peers []string) (string, error) {
 	client, _ := ag.Route.Select(input)
 	msgs := BuildMessages(ag.Mem.History(), input, name, peers)
-	specs := buildToolSpecs(ag.Tools)
+	specs := tool.BuildSpecs(ag.Tools)
 	for i := 0; i < 8; i++ {
 		res, err := client.Complete(ctx, msgs, specs)
 		if err != nil {
@@ -121,16 +121,4 @@ func runAgent(ctx context.Context, ag *core.Agent, input, name string, peers []s
 		ag.Mem.AddStep(step)
 	}
 	return "", errors.New("max iterations")
-}
-
-func buildToolSpecs(reg tool.Registry) []model.ToolSpec {
-	specs := make([]model.ToolSpec, 0, len(reg))
-	for _, t := range reg {
-		specs = append(specs, model.ToolSpec{
-			Name:        t.Name(),
-			Description: t.Description(),
-			Parameters:  t.JSONSchema(),
-		})
-	}
-	return specs
 }

--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -34,7 +34,7 @@ func (a *Agent) Run(ctx context.Context, input string) (string, error) {
 	client, name := a.Route.Select(input)
 	a.Trace(ctx, trace.EventModelStart, name)
 	msgs := buildMessages(a.Mem.History(), input)
-	specs := buildToolSpecs(a.Tools)
+	specs := tool.BuildSpecs(a.Tools)
 	for i := 0; i < 8; i++ {
 		res, err := client.Complete(ctx, msgs, specs)
 		if err != nil {
@@ -93,16 +93,4 @@ func buildMessages(hist []memory.Step, input string) []model.ChatMessage {
 	}
 	msgs = append(msgs, model.ChatMessage{Role: "user", Content: input})
 	return msgs
-}
-
-func buildToolSpecs(reg tool.Registry) []model.ToolSpec {
-	specs := make([]model.ToolSpec, 0, len(reg))
-	for _, t := range reg {
-		specs = append(specs, model.ToolSpec{
-			Name:        t.Name(),
-			Description: t.Description(),
-			Parameters:  t.JSONSchema(),
-		})
-	}
-	return specs
 }

--- a/internal/tool/spec.go
+++ b/internal/tool/spec.go
@@ -1,0 +1,16 @@
+package tool
+
+import "github.com/marcodenic/agentry/internal/model"
+
+// BuildSpecs converts a Registry into model.ToolSpec definitions.
+func BuildSpecs(reg Registry) []model.ToolSpec {
+	specs := make([]model.ToolSpec, 0, len(reg))
+	for _, t := range reg {
+		specs = append(specs, model.ToolSpec{
+			Name:        t.Name(),
+			Description: t.Description(),
+			Parameters:  t.JSONSchema(),
+		})
+	}
+	return specs
+}

--- a/tests/tool_spec_test.go
+++ b/tests/tool_spec_test.go
@@ -1,0 +1,34 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/tool"
+)
+
+func TestBuildSpecs(t *testing.T) {
+	reg := tool.Registry{
+		"foo": tool.New("foo", "Foo tool", func(ctx context.Context, args map[string]any) (string, error) { return "", nil }),
+		"bar": tool.NewWithSchema("bar", "Bar tool", map[string]any{"type": "object"}, func(ctx context.Context, args map[string]any) (string, error) { return "ok", nil }),
+	}
+
+	specs := tool.BuildSpecs(reg)
+	if len(specs) != 2 {
+		t.Fatalf("expected 2 specs got %d", len(specs))
+	}
+
+	found := map[string]bool{}
+	for _, s := range specs {
+		if s.Name == "foo" && s.Description == "Foo tool" {
+			found["foo"] = true
+		}
+		if s.Name == "bar" && s.Description == "Bar tool" {
+			found["bar"] = true
+		}
+	}
+
+	if !found["foo"] || !found["bar"] {
+		t.Fatalf("specs missing: %v", found)
+	}
+}


### PR DESCRIPTION
## Summary
- add `tool.BuildSpecs` helper
- use the helper in `agent` and `runner`
- test new helper

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852aaf50b788320b3cb66c2943e2e85