### PR TITLE
Use context in fetch builtin

### DIFF
--- a/internal/tool/manifest.go
+++ b/internal/tool/manifest.go
@@ -161,7 +161,11 @@ var builtinMap = map[string]builtinSpec{
 			if u == "" {
 				return "", errors.New("missing url")
 			}
-			resp, err := http.Get(u)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+			if err != nil {
+				return "", err
+			}
+			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				return "", err
 			}

--- a/tests/fetch_cancel_test.go
+++ b/tests/fetch_cancel_test.go
@@ -1,0 +1,36 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/marcodenic/agentry/internal/tool"
+)
+
+func TestFetchCanceledContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	tl, ok := tool.DefaultRegistry().Use("fetch")
+	if !ok {
+		t.Fatal("fetch tool not found")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, err := tl.Execute(ctx, map[string]any{"url": srv.URL})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- make fetch builtin honor context cancellation via `http.NewRequestWithContext`
- add regression test ensuring request is canceled

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852aaf925288320b9e00c8891717bcb