### PR TITLE
Fix serve command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 	go install ./cmd/agentry
 
 serve: build
-	agentry --mode=serve --config examples/.agentry.yaml
+	agentry serve --config examples/.agentry.yaml
 
 dev: test build
-	agentry --mode=serve --config examples/.agentry.yaml
+	agentry serve --config examples/.agentry.yaml


### PR DESCRIPTION
## Summary
- update `serve` and `dev` targets to use `agentry serve`

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852aafa126083208a02cb4f1a476901