### PR TITLE
Add MCP builtin tool

### DIFF
--- a/tests/builtin_cross_test.go
+++ b/tests/builtin_cross_test.go
@@ -19,7 +19,7 @@ func TestBuiltinsCrossPlatform(t *testing.T) {
 			ex["path"] = filepath.Join("..", p)
 		}
 		t.Run(name, func(t *testing.T) {
-			if name == "patch" || name == "ping" || name == "fetch" || name == "sourcegraph" {
+			if name == "patch" || name == "ping" || name == "fetch" || name == "sourcegraph" || name == "mcp" {
 				t.Skip("skip network-dependent tool")
 			}
 			_, err := tl.Execute(ctx, ex)

--- a/tests/mcp_test.go
+++ b/tests/mcp_test.go
@@ -1,0 +1,36 @@
+package tests
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/tool"
+)
+
+func TestMcpBuiltin(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 32)
+		n, _ := conn.Read(buf)
+		conn.Write([]byte("resp:" + string(buf[:n])))
+	}()
+	port := ln.Addr().(*net.TCPAddr).Port
+	tl := tool.DefaultRegistry()["mcp"]
+	out, err := tl.Execute(context.Background(), map[string]any{"host": "127.0.0.1", "port": port, "command": "hi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "resp:hi" {
+		t.Fatalf("expected resp:hi, got %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add `mcp` builtin tool
- support executing MCP via TCP and implement timeout handling
- test MCP builtin and skip it in cross platform tests

## Testing
- `go test ./...`
- `npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852ab60add88320ba0363ba68d2a3c2