### PR TITLE
Add layered config support

### DIFF
--- a/cmd/agentry/main.go
+++ b/cmd/agentry/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -30,6 +31,10 @@ func main() {
 	args := os.Args[2:]
 	fs := flag.NewFlagSet(cmd, flag.ExitOnError)
 	conf := fs.String("config", "", "path to .agentry.yaml")
+	theme := fs.String("theme", "", "theme name override")
+	keybinds := fs.String("keybinds", "", "path to keybinds json")
+	credsPath := fs.String("creds", "", "path to credentials json")
+	mcpFlag := fs.String("mcp", "", "comma-separated MCP servers")
 	_ = fs.Parse(args)
 	var configPath string
 	if *conf != "" {
@@ -96,6 +101,31 @@ func main() {
 			fmt.Printf("failed to load config: %v\n", err)
 			os.Exit(1)
 		}
+		if *theme != "" {
+			if cfg.Themes == nil {
+				cfg.Themes = map[string]string{}
+			}
+			cfg.Themes["active"] = *theme
+		}
+		if *keybinds != "" {
+			if b, err := os.ReadFile(*keybinds); err == nil {
+				_ = json.Unmarshal(b, &cfg.Keybinds)
+			}
+		}
+		if *credsPath != "" {
+			if b, err := os.ReadFile(*credsPath); err == nil {
+				_ = json.Unmarshal(b, &cfg.Credentials)
+			}
+		}
+		if *mcpFlag != "" {
+			if cfg.MCPServers == nil {
+				cfg.MCPServers = map[string]string{}
+			}
+			parts := strings.Split(*mcpFlag, ",")
+			for i, p := range parts {
+				cfg.MCPServers[fmt.Sprintf("srv%d", i+1)] = strings.TrimSpace(p)
+			}
+		}
 		ag, err := buildAgent(cfg)
 		if err != nil {
 			panic(err)
@@ -108,6 +138,31 @@ func main() {
 		if err != nil {
 			fmt.Printf("failed to load config: %v\n", err)
 			os.Exit(1)
+		}
+		if *theme != "" {
+			if cfg.Themes == nil {
+				cfg.Themes = map[string]string{}
+			}
+			cfg.Themes["active"] = *theme
+		}
+		if *keybinds != "" {
+			if b, err := os.ReadFile(*keybinds); err == nil {
+				_ = json.Unmarshal(b, &cfg.Keybinds)
+			}
+		}
+		if *credsPath != "" {
+			if b, err := os.ReadFile(*credsPath); err == nil {
+				_ = json.Unmarshal(b, &cfg.Credentials)
+			}
+		}
+		if *mcpFlag != "" {
+			if cfg.MCPServers == nil {
+				cfg.MCPServers = map[string]string{}
+			}
+			parts := strings.Split(*mcpFlag, ",")
+			for i, p := range parts {
+				cfg.MCPServers[fmt.Sprintf("srv%d", i+1)] = strings.TrimSpace(p)
+			}
 		}
 		key := os.Getenv("OPENAI_KEY")
 		if key != "" {
@@ -134,6 +189,31 @@ func main() {
 		if err != nil {
 			fmt.Printf("failed to load config: %v\n", err)
 			os.Exit(1)
+		}
+		if *theme != "" {
+			if cfg.Themes == nil {
+				cfg.Themes = map[string]string{}
+			}
+			cfg.Themes["active"] = *theme
+		}
+		if *keybinds != "" {
+			if b, err := os.ReadFile(*keybinds); err == nil {
+				_ = json.Unmarshal(b, &cfg.Keybinds)
+			}
+		}
+		if *credsPath != "" {
+			if b, err := os.ReadFile(*credsPath); err == nil {
+				_ = json.Unmarshal(b, &cfg.Credentials)
+			}
+		}
+		if *mcpFlag != "" {
+			if cfg.MCPServers == nil {
+				cfg.MCPServers = map[string]string{}
+			}
+			parts := strings.Split(*mcpFlag, ",")
+			for i, p := range parts {
+				cfg.MCPServers[fmt.Sprintf("srv%d", i+1)] = strings.TrimSpace(p)
+			}
 		}
 		ag, err := buildAgent(cfg)
 		if err != nil {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1,45 +1,117 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
 
 type ToolManifest struct {
-	Name        string         `yaml:"name"`
-	Description string         `yaml:"description"`
-	Type        string         `yaml:"type,omitempty"`
-	Command     string         `yaml:"command,omitempty"`
-	HTTP        string         `yaml:"http,omitempty"`
-	Args        map[string]any `yaml:"args,omitempty"`
+	Name        string         `yaml:"name" json:"name"`
+	Description string         `yaml:"description" json:"description"`
+	Type        string         `yaml:"type,omitempty" json:"type,omitempty"`
+	Command     string         `yaml:"command,omitempty" json:"command,omitempty"`
+	HTTP        string         `yaml:"http,omitempty" json:"http,omitempty"`
+	Args        map[string]any `yaml:"args,omitempty" json:"args,omitempty"`
 }
 
 type ModelManifest struct {
-	Name     string            `yaml:"name"`
-	Provider string            `yaml:"provider"`
-	Options  map[string]string `yaml:"options,omitempty"`
+	Name     string            `yaml:"name" json:"name"`
+	Provider string            `yaml:"provider" json:"provider"`
+	Options  map[string]string `yaml:"options,omitempty" json:"options,omitempty"`
 }
 
 type RouteRule struct {
-	IfContains []string `yaml:"if_contains"`
-	Model      string   `yaml:"model"`
+	IfContains []string `yaml:"if_contains" json:"if_contains"`
+	Model      string   `yaml:"model" json:"model"`
 }
 
 type File struct {
-	Models []ModelManifest `yaml:"models"`
-	Routes []RouteRule     `yaml:"routes"`
-	Tools  []ToolManifest  `yaml:"tools"`
+	Models      []ModelManifest              `yaml:"models" json:"models"`
+	Routes      []RouteRule                  `yaml:"routes" json:"routes"`
+	Tools       []ToolManifest               `yaml:"tools" json:"tools"`
+	Themes      map[string]string            `yaml:"themes" json:"themes"`
+	Keybinds    map[string]string            `yaml:"keybinds" json:"keybinds"`
+	Credentials map[string]map[string]string `yaml:"credentials" json:"credentials"`
+	MCPServers  map[string]string            `yaml:"mcp_servers" json:"mcp_servers"`
+}
+
+func merge(dst *File, src File) {
+	if len(src.Models) > 0 {
+		dst.Models = src.Models
+	}
+	if len(src.Routes) > 0 {
+		dst.Routes = src.Routes
+	}
+	if len(src.Tools) > 0 {
+		dst.Tools = src.Tools
+	}
+	if dst.Themes == nil {
+		dst.Themes = map[string]string{}
+	}
+	for k, v := range src.Themes {
+		dst.Themes[k] = v
+	}
+	if dst.Keybinds == nil {
+		dst.Keybinds = map[string]string{}
+	}
+	for k, v := range src.Keybinds {
+		dst.Keybinds[k] = v
+	}
+	if dst.Credentials == nil {
+		dst.Credentials = map[string]map[string]string{}
+	}
+	for k, v := range src.Credentials {
+		dst.Credentials[k] = v
+	}
+	if dst.MCPServers == nil {
+		dst.MCPServers = map[string]string{}
+	}
+	for k, v := range src.MCPServers {
+		dst.MCPServers[k] = v
+	}
 }
 
 func Load(path string) (*File, error) {
+	var out File
+
+	configHome := os.Getenv("AGENTRY_CONFIG_HOME")
+	if configHome == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			configHome = filepath.Join(home, ".config", "agentry")
+		}
+	}
+	if configHome != "" {
+		p := filepath.Join(configHome, "config.json")
+		if b, err := os.ReadFile(p); err == nil {
+			var f File
+			if json.Unmarshal(b, &f) == nil {
+				merge(&out, f)
+			}
+		}
+	}
+
+	projDir := filepath.Dir(path)
+	if projDir == "." || projDir == "" {
+		projDir, _ = os.Getwd()
+	}
+	if b, err := os.ReadFile(filepath.Join(projDir, "agentry.json")); err == nil {
+		var f File
+		if json.Unmarshal(b, &f) == nil {
+			merge(&out, f)
+		}
+	}
+
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	var f File
-	if err := yaml.Unmarshal(b, &f); err != nil {
+	var yamlFile File
+	if err := yaml.Unmarshal(b, &yamlFile); err != nil {
 		return nil, err
 	}
-	return &f, nil
+	merge(&out, yamlFile)
+	return &out, nil
 }


### PR DESCRIPTION
## Summary
- allow project and user JSON config to overlay YAML
- add optional theme, keybind, credential, and MCP sections
- expose CLI flags for overriding these sections

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68583c5db4cc83208603690da2946e99