### PR TITLE
Add TUI theming and keybinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,26 @@ Run `agentry tui --config examples/.agentry.yaml` to try.
 
 ---
 
+### 🎨 Themes & Keybinds
+
+Create a `theme.json` file to customise colours and keyboard shortcuts. Agentry
+looks for the file in the current directory and its parents, falling back to
+`$HOME/.config/agentry/theme.json`. Settings override the built‑in defaults.
+
+```json
+{
+  "userBarColor": "#00FF00",
+  "aiBarColor": "#FF00FF",
+  "keybinds": {
+    "quit": "ctrl+c",
+    "toggleTab": "tab",
+    "submit": "enter"
+  }
+}
+```
+
+---
+
 ## 🧰 Built-in Tools
 
 Agentry ships with a collection of safe builtin tools. They become available to the agent when listed in your `.agentry.yaml` file:

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Keybinds define keyboard shortcuts for the TUI actions.
+type Keybinds struct {
+	Quit      string `json:"quit"`
+	ToggleTab string `json:"toggleTab"`
+	Submit    string `json:"submit"`
+}
+
+// Theme holds colour settings and keybinds.
+type Theme struct {
+	UserBarColor string   `json:"userBarColor"`
+	AIBarColor   string   `json:"aiBarColor"`
+	Keybinds     Keybinds `json:"keybinds"`
+}
+
+// DefaultTheme returns built‑in colours and keybindings.
+func DefaultTheme() Theme {
+	return Theme{
+		UserBarColor: "#8B5CF6",
+		AIBarColor:   "#9CA3AF",
+		Keybinds: Keybinds{
+			Quit:      "ctrl+c",
+			ToggleTab: "tab",
+			Submit:    "enter",
+		},
+	}
+}
+
+// LoadTheme loads theme.json from the current directory hierarchy or
+// "$HOME/.config/agentry". Local files override global ones.
+func LoadTheme() Theme {
+	t := DefaultTheme()
+
+	if home, err := os.UserHomeDir(); err == nil {
+		if b, err := os.ReadFile(filepath.Join(home, ".config", "agentry", "theme.json")); err == nil {
+			_ = json.Unmarshal(b, &t)
+		}
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		return t
+	}
+	for {
+		if b, err := os.ReadFile(filepath.Join(dir, "theme.json")); err == nil {
+			_ = json.Unmarshal(b, &t)
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return t
+}


### PR DESCRIPTION
## Summary
- load `theme.json` hierarchically and expose a simple `Theme` type
- allow configurable keybinds and colours in the TUI model
- document how to customise the interface

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68583c8ab820832084d5389a9bce80ad