### PR TITLE
Add GitHub Actions workflow for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Build binary
+        run: |
+          mkdir -p dist
+          GOOS=${{ matrix.goos }} GOARCH=amd64 CGO_ENABLED=0 \
+          go build -o dist/agentry-${{ matrix.goos }}-amd64${{ matrix.goos == 'windows' && '.exe' || '' }} ./cmd/agentry
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentry-${{ matrix.goos }}
+          path: dist/*
+  
+  release:
+    name: Publish GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/**/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Introduces a release workflow that builds binaries for Linux, macOS, and Windows on tag pushes and publishes them as GitHub Releases.