### PR TITLE
docs: add initial cloud design docs

### DIFF
--- a/README-cloud.md
+++ b/README-cloud.md
@@ -1,0 +1,41 @@
+# Agentry Cloud Architecture
+
+This document outlines the planned cloud deployment model for Agentry.
+
+## Overview
+
+Agentry exposes a minimal HTTP API backed by the Go runtime. Clients (CLI, SDK, or other services) send requests to the API which orchestrates tools and models.
+
+```
+[Client] -> [HTTP API] -> [Agent Runtime] -> [Tools/LLM]
+                      -> [Memory]
+```
+
+```mermaid
+flowchart LR
+    subgraph Frontend
+        CLI
+        SDK
+    end
+    CLI --> API
+    SDK --> API
+    API((HTTP API)) --> Runtime
+    Runtime --> Tools
+    Runtime --> LLM((LLM))
+    Runtime --> Memory
+```
+
+## Repository Layout
+
+```
+.
+├── cmd/           # CLI entrypoints
+├── internal/      # core runtime packages
+├── ts-sdk/        # TypeScript SDK
+├── design/        # architecture notes
+├── examples/      # sample configs and data
+├── tests/         # Go test suites
+└── README-cloud.md
+```
+
+This layout may evolve as the distributed scheduler and sandbox features mature.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Agentry is a production-ready **agent runtime** written in Go with an optional TypeScript client.
 
+For the upcoming cloud deployment model, see [README-cloud.md](./README-cloud.md).
+
 ---
 
 | 🚩 **Pillar**        | ✨ **v1.0 Features**                                     |

--- a/design/distributed_arch.md
+++ b/design/distributed_arch.md
@@ -1,0 +1,3 @@
+# Distributed Architecture
+
+High-level approach for scaling Agentry across multiple nodes and workers.

--- a/design/flow_dsl.md
+++ b/design/flow_dsl.md
@@ -1,0 +1,3 @@
+# Flow DSL
+
+Initial notes on a declarative Domain Specific Language for orchestrating agent workflows.

--- a/design/sandbox.md
+++ b/design/sandbox.md
@@ -1,0 +1,3 @@
+# Sandbox Architecture
+
+Overview of execution sandboxing for secure tool and plugin isolation.


### PR DESCRIPTION
## Summary
- document the new Agentry Cloud architecture
- add initial design notes for flow DSL, sandboxing and distributed modes
- link from the main README to the cloud overview

## Testing
- `go test ./...`
- `npm test` inside `ts-sdk`

------
https://chatgpt.com/codex/tasks/task_e_685868101bec8320a23501343bc64463