### PR TITLE
feat(flow): add initial DSL parser

### DIFF
--- a/pkg/flow/parser.go
+++ b/pkg/flow/parser.go
@@ -1,0 +1,77 @@
+package flow
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+type File struct {
+	Agents map[string]Agent `yaml:"agents"`
+	Tasks  []Task           `yaml:"tasks"`
+}
+
+type Agent struct {
+	Model  string            `yaml:"model"`
+	Prompt string            `yaml:"prompt,omitempty"`
+	Tools  []string          `yaml:"tools,omitempty"`
+	Env    map[string]string `yaml:"env,omitempty"`
+}
+
+type Task struct {
+	Agent      string            `yaml:"agent,omitempty"`
+	Input      string            `yaml:"input,omitempty"`
+	Sequential []Task            `yaml:"sequential,omitempty"`
+	Parallel   []Task            `yaml:"parallel,omitempty"`
+	Env        map[string]string `yaml:"env,omitempty"`
+}
+
+// Load reads and validates a flow file.
+func Load(path string) (*File, error) {
+	if fi, err := os.Stat(path); err == nil && fi.IsDir() {
+		path = filepath.Join(path, ".agentry.flow.yaml")
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var f File
+	if err := yaml.Unmarshal(b, &f); err != nil {
+		return nil, err
+	}
+	if len(f.Agents) == 0 {
+		return nil, errors.New("no agents defined")
+	}
+	for i, t := range f.Tasks {
+		if err := validateTask(t, f.Agents); err != nil {
+			return nil, fmt.Errorf("task %d: %w", i, err)
+		}
+	}
+	return &f, nil
+}
+
+func validateTask(t Task, agents map[string]Agent) error {
+	if t.Agent == "" && len(t.Sequential) == 0 && len(t.Parallel) == 0 {
+		return errors.New("task must define agent or subtasks")
+	}
+	if t.Agent != "" {
+		if _, ok := agents[t.Agent]; !ok {
+			return fmt.Errorf("undefined agent %q", t.Agent)
+		}
+	}
+	for i, st := range t.Sequential {
+		if err := validateTask(st, agents); err != nil {
+			return fmt.Errorf("sequential[%d]: %w", i, err)
+		}
+	}
+	for i, st := range t.Parallel {
+		if err := validateTask(st, agents); err != nil {
+			return fmt.Errorf("parallel[%d]: %w", i, err)
+		}
+	}
+	return nil
+}

--- a/tests/flow_parser_test.go
+++ b/tests/flow_parser_test.go
@@ -1,0 +1,46 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marcodenic/agentry/pkg/flow"
+)
+
+func TestFlowParseSuccess(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `agents:
+  coder:
+    model: gpt-4
+tasks:
+  - agent: coder
+    input: build
+`
+	if err := os.WriteFile(filepath.Join(dir, ".agentry.flow.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := flow.Load(dir)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if len(f.Agents) != 1 || len(f.Tasks) != 1 {
+		t.Fatalf("unexpected parsed data: %#v", f)
+	}
+}
+
+func TestFlowParseUndefinedAgent(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `agents:
+  coder:
+    model: gpt-4
+tasks:
+  - agent: missing
+    input: build
+`
+	os.WriteFile(filepath.Join(dir, ".agentry.flow.yaml"), []byte(yaml), 0644)
+	_, err := flow.Load(dir)
+	if err == nil {
+		t.Fatalf("expected error for undefined agent")
+	}
+}


### PR DESCRIPTION
## Summary
- create `pkg/flow` parser for `.agentry.flow.yaml`
- validate tasks reference known agents
- add unit tests for parser success and failure cases

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858682681f8832099e6be1b3e5cabd4