### PR TITLE
Add lint and eval to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
         with:
           go-version: "1.23"
 
+      - name: Install and run golangci-lint
+        run: |
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          $(go env GOPATH)/bin/golangci-lint run
+
       - name: Run Go tests
         run: go test ./...
 
@@ -30,3 +35,6 @@ jobs:
         run: |
           npm ci
           npm test
+
+      - name: Run agentry eval
+        run: go run ./cmd/agentry eval examples/.agentry.yaml


### PR DESCRIPTION
## Summary
- run `golangci-lint` in CI
- execute `agentry eval` using example config

## Testing
- `go test ./...`
- `cd ts-sdk && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858683553c883208a2ab6c416d1323d