### PR TITLE
Update CI to check license file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Ensure LICENSE exists
+        run: test -f LICENSE
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Summary
- fail CI if the `LICENSE` file is missing

## Testing
- `go test ./...`
- `npm test` in `ts-sdk`


------
https://chatgpt.com/codex/tasks/task_e_68586851c8108320bcec0c47e4094036