### PR TITLE
docs: update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ go install github.com/marcodenic/agentry/cmd/agentry@latest
 agentry dev
 
 # 🌐 HTTP server + JS client
-agentry serve --config .agentry.yaml
+agentry serve --config examples/.agentry.yaml
 npm i @marcodenic/agentry
 ```
+
+The `examples/.agentry.yaml` file contains a ready-to-use configuration for these commands.
 
 You can now use subcommands instead of the --mode flag:
 


### PR DESCRIPTION
## Summary
- fix quick start instructions to use example config
- clarify that the example config lives in `examples/.agentry.yaml`

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68586860622c83209e99fdec7400aa04