### PR TITLE
Implement sandbox executor and config flags

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -15,6 +15,10 @@ type ToolManifest struct {
 	Command     string         `yaml:"command,omitempty" json:"command,omitempty"`
 	HTTP        string         `yaml:"http,omitempty" json:"http,omitempty"`
 	Args        map[string]any `yaml:"args,omitempty" json:"args,omitempty"`
+	Privileged  bool           `yaml:"privileged,omitempty" json:"privileged,omitempty"`
+	Net         string         `yaml:"net,omitempty" json:"net,omitempty"`
+	CPULimit    string         `yaml:"cpu_limit,omitempty" json:"cpu_limit,omitempty"`
+	MemLimit    string         `yaml:"mem_limit,omitempty" json:"mem_limit,omitempty"`
 }
 
 type ModelManifest struct {

--- a/pkg/sbox/sbox.go
+++ b/pkg/sbox/sbox.go
@@ -1,0 +1,57 @@
+package sbox
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// Options controls sandboxed execution.
+type Options struct {
+	Engine   string // "docker" or "gvisor"
+	Net      string
+	CPULimit string
+	MemLimit string
+}
+
+// RunCommand is used to execute external commands. It can be replaced in tests.
+var RunCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, name, args...)
+}
+
+// Exec runs a shell command inside Docker or gVisor according to opts.
+func Exec(ctx context.Context, cmdStr string, opts Options) (string, error) {
+	engine := opts.Engine
+	if engine == "" {
+		engine = "docker"
+	}
+	args := buildArgs(engine, cmdStr, opts)
+	if len(args) == 0 {
+		return "", fmt.Errorf("unknown engine %s", engine)
+	}
+	cmd := RunCommand(ctx, args[0], args[1:]...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func buildArgs(engine, cmdStr string, opts Options) []string {
+	switch engine {
+	case "docker":
+		args := []string{"docker", "run", "--rm", "-v", "/workspace:/workspace"}
+		if opts.Net != "" {
+			args = append(args, "--network", opts.Net)
+		}
+		if opts.CPULimit != "" {
+			args = append(args, "--cpus", opts.CPULimit)
+		}
+		if opts.MemLimit != "" {
+			args = append(args, "--memory", opts.MemLimit)
+		}
+		args = append(args, "alpine", "sh", "-c", cmdStr)
+		return args
+	case "gvisor":
+		return []string{"runsc", "bash", "-c", cmdStr}
+	default:
+		return nil
+	}
+}

--- a/tests/sandbox_test.go
+++ b/tests/sandbox_test.go
@@ -1,0 +1,61 @@
+package tests
+
+import (
+	"context"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/marcodenic/agentry/pkg/sbox"
+)
+
+func TestSandboxDockerArgs(t *testing.T) {
+	var got []string
+	sbox.RunCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		got = append([]string{name}, args...)
+		return exec.CommandContext(ctx, "echo", "ok")
+	}
+	defer func() {
+		sbox.RunCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, name, args...)
+		}
+	}()
+
+	out, err := sbox.Exec(context.Background(), "echo hi", sbox.Options{Net: "host", CPULimit: "1", MemLimit: "512m"})
+	if err != nil {
+		t.Fatalf("exec failed: %v", err)
+	}
+	if strings.TrimSpace(out) != "ok" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+	want := []string{"docker", "run", "--rm", "-v", "/workspace:/workspace", "--network", "host", "--cpus", "1", "--memory", "512m", "alpine", "sh", "-c", "echo hi"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestSandboxGVisor(t *testing.T) {
+	var got []string
+	sbox.RunCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		got = append([]string{name}, args...)
+		return exec.CommandContext(ctx, "echo", "ok")
+	}
+	defer func() {
+		sbox.RunCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, name, args...)
+		}
+	}()
+
+	out, err := sbox.Exec(context.Background(), "echo hi", sbox.Options{Engine: "gvisor"})
+	if err != nil {
+		t.Fatalf("exec failed: %v", err)
+	}
+	if strings.TrimSpace(out) != "ok" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+	want := []string{"runsc", "bash", "-c", "echo hi"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}

--- a/tests/tool_manifest_test.go
+++ b/tests/tool_manifest_test.go
@@ -48,7 +48,7 @@ func TestFromManifestHTTP(t *testing.T) {
 }
 
 func TestFromManifestCommand(t *testing.T) {
-	m := config.ToolManifest{Name: "local", Command: "echo hi", Description: ""}
+	m := config.ToolManifest{Name: "local", Command: "echo hi", Description: "", Privileged: true}
 	tl, err := tool.FromManifest(m)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- create `pkg/sbox` providing Docker/gVisor execution helpers
- support sandbox related fields in `ToolManifest`
- use sandbox when running non-privileged command tools
- add sandbox execution tests
- update manifest command test

## Testing
- `go test ./...`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586f7f0fec83208eeb4b718e303dc6