### PR TITLE
Add plugin install command and registration

### DIFF
--- a/cmd/agentry/main.go
+++ b/cmd/agentry/main.go
@@ -229,6 +229,8 @@ func main() {
 		if err := p.Start(); err != nil {
 			panic(err)
 		}
+	case "plugin":
+		runPluginCmd(args)
 	default:
 		fmt.Println("unknown command. Usage: agentry [dev|serve|tui|eval] [--config path/to/config.yaml]")
 		os.Exit(1)

--- a/cmd/agentry/plugin.go
+++ b/cmd/agentry/plugin.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/marcodenic/agentry/internal/plugin"
+)
+
+func runPluginCmd(args []string) {
+	if len(args) == 0 {
+		fmt.Println("Usage: agentry plugin <command> [args]")
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "install":
+		if len(args) < 2 {
+			fmt.Println("Usage: agentry plugin install <repo>")
+			os.Exit(1)
+		}
+		if err := plugin.Install(args[1]); err != nil {
+			fmt.Printf("install failed: %v\n", err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Printf("unknown plugin command %s\n", args[0])
+		os.Exit(1)
+	}
+}

--- a/internal/plugin/install.go
+++ b/internal/plugin/install.go
@@ -1,0 +1,46 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// ExecCommand allows tests to override exec.Command.
+var ExecCommand = exec.Command
+
+// ManifestFile stores installed plugin repositories.
+const ManifestFile = ".agentry.plugins.json"
+
+// Install clones a repository and installs it via go install.
+func Install(repo string) error {
+	dir, err := os.MkdirTemp("", "agentry-plugin-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+
+	if out, err := ExecCommand("git", "clone", repo, dir).CombinedOutput(); err != nil {
+		return fmt.Errorf("git clone: %v: %s", err, out)
+	}
+
+	cmd := ExecCommand("go", "install")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("go install: %v: %s", err, out)
+	}
+
+	var plugins []string
+	if b, err := os.ReadFile(ManifestFile); err == nil {
+		_ = json.Unmarshal(b, &plugins)
+	}
+	for _, p := range plugins {
+		if p == repo {
+			return nil
+		}
+	}
+	plugins = append(plugins, repo)
+	b, _ := json.MarshalIndent(plugins, "", "  ")
+	return os.WriteFile(ManifestFile, b, 0644)
+}

--- a/internal/tool/plugin.go
+++ b/internal/tool/plugin.go
@@ -1,0 +1,6 @@
+package tool
+
+// Register allows plugins to add custom builtin tools via init().
+func Register(name, desc string, schema map[string]any, fn ExecFn) {
+	builtinMap[name] = builtinSpec{Desc: desc, Schema: schema, Exec: fn}
+}

--- a/tests/plugin_install_test.go
+++ b/tests/plugin_install_test.go
@@ -1,0 +1,48 @@
+package tests
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/plugin"
+)
+
+func TestInstallPluginUpdatesManifest(t *testing.T) {
+	dir := t.TempDir()
+	cwd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(cwd)
+
+	var cmds [][]string
+	plugin.ExecCommand = func(name string, args ...string) *exec.Cmd {
+		cmds = append(cmds, append([]string{name}, args...))
+		return exec.Command("true")
+	}
+	defer func() { plugin.ExecCommand = exec.Command }()
+
+	repo := "github.com/example/plugin"
+	if err := plugin.Install(repo); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	b, err := os.ReadFile(plugin.ManifestFile)
+	if err != nil {
+		t.Fatalf("manifest read: %v", err)
+	}
+	var repos []string
+	if err := json.Unmarshal(b, &repos); err != nil {
+		t.Fatalf("manifest json: %v", err)
+	}
+	if len(repos) != 1 || repos[0] != repo {
+		t.Fatalf("unexpected manifest %v", repos)
+	}
+
+	if len(cmds) != 2 {
+		t.Fatalf("expected 2 commands, got %d", len(cmds))
+	}
+	if cmds[0][0] != "git" || cmds[1][0] != "go" {
+		t.Fatalf("unexpected commands %v", cmds)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `agentry plugin install` command
- support plugin registration via new `tool.Register`
- allow programmatic installation via `internal/plugin` package
- add tests for plugin installation behavior

## Testing
- `go test ./...`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68586f82369483208a39dee4c90a1758