### PR TITLE
Spawn agent per request and add concurrency test

### DIFF
--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -25,11 +25,12 @@ func Handler(agents map[string]*core.Agent, metrics bool) http.Handler {
 			http.Error(w, "bad json", http.StatusBadRequest)
 			return
 		}
-		ag := agents[in.AgentID]
-		if ag == nil {
+		base := agents[in.AgentID]
+		if base == nil {
 			http.Error(w, "unknown agent", http.StatusBadRequest)
 			return
 		}
+		ag := base.Spawn()
 		if in.Stream {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.Header().Set("Cache-Control", "no-cache")

--- a/tests/server_concurrent_test.go
+++ b/tests/server_concurrent_test.go
@@ -1,0 +1,62 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/server"
+)
+
+func TestServerConcurrentInvoke(t *testing.T) {
+	ag := newAgent("ok", nil)
+	agents := map[string]*core.Agent{"a": ag}
+
+	srv := httptest.NewServer(server.Handler(agents, false))
+	defer srv.Close()
+
+	const n = 10
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			body := bytes.NewBufferString(`{"agent_id":"a","input":"hi"}`)
+			resp, err := http.Post(srv.URL+"/invoke", "application/json", body)
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				b, _ := io.ReadAll(resp.Body)
+				errs <- fmt.Errorf("status %d: %s", resp.StatusCode, string(b))
+				return
+			}
+			var out struct {
+				Output string `json:"output"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+				errs <- err
+				return
+			}
+			if out.Output != "ok" {
+				errs <- fmt.Errorf("unexpected output %s", out.Output)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- spawn a fresh agent on each HTTP invocation so requests don't share state
- update invocation handler to set tracer on the per-request agent
- add `TestServerConcurrentInvoke` that sends concurrent requests
- use stateless simple agents in the concurrency test

## Testing
- `go test -race ./...`


------
https://chatgpt.com/codex/tasks/task_e_68586f8ef53483208d2cb4a056b86442