### PR TITLE
Add memstore path and state flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ You can now use subcommands instead of the --mode flag:
 - `agentry tui` (TUI interface)
 - `agentry eval` (evaluation)
 
+Pass `--resume-id name` to load a saved session and `--save-id name` to persist after each run.
+
 The new `tui` command launches a split-screen interface:
 
 ```
@@ -196,6 +198,16 @@ converse 3 Pick a favourite movie, just one, then discuss as a group.
 ```
 
 The first number selects how many agents join the chat. Any remaining text becomes the opening message. If omitted, a generic greeting is used.
+
+### 💾 Saving & Resuming
+
+Add a `store` path to your `.agentry.yaml` to enable persistence:
+
+```yaml
+store: path/to/db.sqlite
+```
+
+Run the CLI with `--resume-id myrun` to load a snapshot before running and `--save-id myrun` to save state after each run.
 
 ---
 

--- a/cmd/agentry/build.go
+++ b/cmd/agentry/build.go
@@ -10,6 +10,7 @@ import (
 	"github.com/marcodenic/agentry/internal/model"
 	"github.com/marcodenic/agentry/internal/router"
 	"github.com/marcodenic/agentry/internal/tool"
+	"github.com/marcodenic/agentry/pkg/memstore"
 )
 
 // buildAgent constructs an Agent from configuration.
@@ -48,6 +49,15 @@ func buildAgent(cfg *config.File) (*core.Agent, error) {
 		rules = router.Rules{{Name: "mock", IfContains: []string{""}, Client: model.NewMock()}}
 	}
 
-	ag := core.New(rules, reg, memory.NewInMemory(), nil, nil)
+	var store memstore.KV
+	if cfg.Store != "" {
+		s, err := memstore.NewSQLite(cfg.Store)
+		if err != nil {
+			return nil, err
+		}
+		store = s
+	}
+
+	ag := core.New(rules, reg, memory.NewInMemory(), store, nil)
 	return ag, nil
 }

--- a/cmd/agentry/main.go
+++ b/cmd/agentry/main.go
@@ -36,6 +36,8 @@ func main() {
 	keybinds := fs.String("keybinds", "", "path to keybinds json")
 	credsPath := fs.String("creds", "", "path to credentials json")
 	mcpFlag := fs.String("mcp", "", "comma-separated MCP servers")
+	saveID := fs.String("save-id", "", "save conversation state to this ID")
+	resumeID := fs.String("resume-id", "", "load conversation state from this ID")
 	_ = fs.Parse(args)
 	var configPath string
 	if *conf != "" {
@@ -55,6 +57,12 @@ func main() {
 		ag, err := buildAgent(cfg)
 		if err != nil {
 			panic(err)
+		}
+		if *resumeID != "" {
+			_ = ag.LoadState(context.Background(), *resumeID)
+		}
+		if *resumeID != "" {
+			_ = ag.LoadState(context.Background(), *resumeID)
 		}
 
 		// tiny REPL
@@ -95,6 +103,9 @@ func main() {
 				continue
 			}
 			fmt.Println(out)
+			if *saveID != "" {
+				_ = ag.SaveState(context.Background(), *saveID)
+			}
 		}
 	case "serve":
 		cfg, err := config.Load(configPath)
@@ -131,6 +142,9 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
+		if *resumeID != "" {
+			_ = ag.LoadState(context.Background(), *resumeID)
+		}
 		if cfg.Metrics {
 			if _, err := trace.Init(); err != nil {
 				fmt.Printf("trace init: %v\n", err)
@@ -138,7 +152,7 @@ func main() {
 		}
 		agents := map[string]*core.Agent{"default": ag}
 		fmt.Println("Serving HTTP on :8080")
-		server.Serve(agents, cfg.Metrics)
+		server.Serve(agents, cfg.Metrics, *saveID, *resumeID)
 	case "eval":
 		cfg, err := config.Load(configPath)
 		if err != nil {
@@ -190,6 +204,9 @@ func main() {
 			suite = "tests/openai_eval_suite.json"
 		}
 		eval.Run(nil, ag, suite)
+		if *saveID != "" {
+			_ = ag.SaveState(context.Background(), *saveID)
+		}
 	case "tui":
 		cfg, err := config.Load(configPath)
 		if err != nil {
@@ -225,9 +242,15 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
+		if *resumeID != "" {
+			_ = ag.LoadState(context.Background(), *resumeID)
+		}
 		p := tea.NewProgram(tui.New(ag))
 		if err := p.Start(); err != nil {
 			panic(err)
+		}
+		if *saveID != "" {
+			_ = ag.SaveState(context.Background(), *saveID)
 		}
 	default:
 		fmt.Println("unknown command. Usage: agentry [dev|serve|tui|eval] [--config path/to/config.yaml]")

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -32,6 +32,7 @@ type File struct {
 	Models      []ModelManifest              `yaml:"models" json:"models"`
 	Routes      []RouteRule                  `yaml:"routes" json:"routes"`
 	Tools       []ToolManifest               `yaml:"tools" json:"tools"`
+	Store       string                       `yaml:"store" json:"store"`
 	Themes      map[string]string            `yaml:"themes" json:"themes"`
 	Keybinds    map[string]string            `yaml:"keybinds" json:"keybinds"`
 	Credentials map[string]map[string]string `yaml:"credentials" json:"credentials"`
@@ -48,6 +49,9 @@ func merge(dst *File, src File) {
 	}
 	if len(src.Tools) > 0 {
 		dst.Tools = src.Tools
+	}
+	if src.Store != "" {
+		dst.Store = src.Store
 	}
 	if dst.Themes == nil {
 		dst.Themes = map[string]string{}

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func Handler(agents map[string]*core.Agent, metrics bool) http.Handler {
+func Handler(agents map[string]*core.Agent, metrics bool, saveID, resumeID string) http.Handler {
 	mux := http.NewServeMux()
 	if metrics {
 		mux.Handle("/metrics", promhttp.Handler())
@@ -43,16 +43,22 @@ func Handler(agents map[string]*core.Agent, metrics bool) http.Handler {
 			}
 			return
 		}
+		if resumeID != "" {
+			_ = ag.LoadState(r.Context(), resumeID)
+		}
 		out, err := ag.Run(r.Context(), in.Input)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 			return
+		}
+		if saveID != "" {
+			_ = ag.SaveState(r.Context(), saveID)
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"output": out})
 	})
 	return mux
 }
 
-func Serve(agents map[string]*core.Agent, metrics bool) error {
-	return http.ListenAndServe(":8080", Handler(agents, metrics))
+func Serve(agents map[string]*core.Agent, metrics bool, saveID, resumeID string) error {
+	return http.ListenAndServe(":8080", Handler(agents, metrics, saveID, resumeID))
 }

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMetricsEndpoint(t *testing.T) {
-	h := server.Handler(nil, true)
+	h := server.Handler(nil, true, "", "")
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 


### PR DESCRIPTION
## Summary
- extend config.File with `Store` path field
- open SQLite memstore in `buildAgent`
- add `--save-id` and `--resume-id` flags to CLI
- persist/resume state in dev REPL, eval, tui and server
- document persistence options and new flags in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68586f7aaee48320bff4bfe2117f1104