### PR TITLE
Add pluggable memory store factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,18 @@ The first number selects how many agents join the chat. Any remaining text becom
 
 ### 💾 Saving & Resuming
 
-Add a `store` path to your `.agentry.yaml` to enable persistence:
+Add a `memory` entry to your `.agentry.yaml` to enable persistence. The value
+uses a URI scheme to select the backend:
 
 ```yaml
-store: path/to/db.sqlite
+# SQLite database
+memory: sqlite:mem.db
+
+# JSON file
+# memory: file:mem.json
+
+# In-memory (ephemeral)
+# memory: mem:
 ```
 
 Run the CLI with `--resume-id myrun` to load a snapshot before running and `--save-id myrun` to save state after each run.

--- a/cmd/agentry/build.go
+++ b/cmd/agentry/build.go
@@ -50,8 +50,12 @@ func buildAgent(cfg *config.File) (*core.Agent, error) {
 	}
 
 	var store memstore.KV
-	if cfg.Store != "" {
-		s, err := memstore.NewSQLite(cfg.Store)
+	memURI := cfg.Memory
+	if memURI == "" {
+		memURI = cfg.Store
+	}
+	if memURI != "" {
+		s, err := memstore.StoreFactory(memURI)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -36,7 +36,8 @@ type File struct {
 	Models      []ModelManifest              `yaml:"models" json:"models"`
 	Routes      []RouteRule                  `yaml:"routes" json:"routes"`
 	Tools       []ToolManifest               `yaml:"tools" json:"tools"`
-	Store       string                       `yaml:"store" json:"store"`
+	Memory      string                       `yaml:"memory" json:"memory"`
+	Store       string                       `yaml:"store" json:"store"` // legacy
 	Themes      map[string]string            `yaml:"themes" json:"themes"`
 	Keybinds    map[string]string            `yaml:"keybinds" json:"keybinds"`
 	Credentials map[string]map[string]string `yaml:"credentials" json:"credentials"`
@@ -53,6 +54,9 @@ func merge(dst *File, src File) {
 	}
 	if len(src.Tools) > 0 {
 		dst.Tools = src.Tools
+	}
+	if src.Memory != "" {
+		dst.Memory = src.Memory
 	}
 	if src.Store != "" {
 		dst.Store = src.Store

--- a/pkg/memstore/factory.go
+++ b/pkg/memstore/factory.go
@@ -1,0 +1,30 @@
+package memstore
+
+import (
+	"fmt"
+	"strings"
+)
+
+// StoreFactory parses a memory URI and returns the appropriate KV store.
+// Supported schemes:
+//
+//	sqlite:/path/to/db.sqlite
+//	file:/path/to/data.json
+//	mem:
+func StoreFactory(uri string) (KV, error) {
+	if uri == "" {
+		return nil, nil
+	}
+	switch {
+	case strings.HasPrefix(uri, "sqlite:"):
+		path := strings.TrimPrefix(uri, "sqlite:")
+		return NewSQLite(path)
+	case strings.HasPrefix(uri, "file:"):
+		path := strings.TrimPrefix(uri, "file:")
+		return NewFile(path)
+	case strings.HasPrefix(uri, "mem:") || uri == "mem":
+		return NewInMemory(), nil
+	default:
+		return nil, fmt.Errorf("unknown memory scheme: %s", uri)
+	}
+}

--- a/pkg/memstore/file.go
+++ b/pkg/memstore/file.go
@@ -1,0 +1,85 @@
+package memstore
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"sync"
+)
+
+// File is a simple JSON-backed store persisted to disk.
+type File struct {
+	path   string
+	mu     sync.RWMutex
+	kv     map[string]map[string][]byte
+	vector map[string]string
+}
+
+func NewFile(path string) (*File, error) {
+	f := &File{
+		path:   path,
+		kv:     map[string]map[string][]byte{},
+		vector: map[string]string{},
+	}
+	if b, err := os.ReadFile(path); err == nil {
+		json.Unmarshal(b, &f.kv)
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+	return f, nil
+}
+
+func (f *File) persist() error {
+	b, err := json.Marshal(f.kv)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(f.path, b, 0644)
+}
+
+func (f *File) Set(_ context.Context, bucket, key string, val []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.kv[bucket] == nil {
+		f.kv[bucket] = map[string][]byte{}
+	}
+	cp := make([]byte, len(val))
+	copy(cp, val)
+	f.kv[bucket][key] = cp
+	return f.persist()
+}
+
+func (f *File) Get(_ context.Context, bucket, key string) ([]byte, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if f.kv[bucket] == nil {
+		return nil, nil
+	}
+	val, ok := f.kv[bucket][key]
+	if !ok {
+		return nil, nil
+	}
+	cp := make([]byte, len(val))
+	copy(cp, val)
+	return cp, nil
+}
+
+func (f *File) Add(_ context.Context, id, text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.vector[id] = text
+	return f.persist()
+}
+
+func (f *File) Query(_ context.Context, _ string, k int) ([]string, error) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	ids := make([]string, 0, k)
+	for id := range f.vector {
+		ids = append(ids, id)
+		if len(ids) >= k {
+			break
+		}
+	}
+	return ids, nil
+}

--- a/pkg/memstore/inmem.go
+++ b/pkg/memstore/inmem.go
@@ -1,0 +1,67 @@
+package memstore
+
+import (
+	"context"
+	"sync"
+)
+
+// InMemory is a simple ephemeral store backed by Go maps.
+type InMemory struct {
+	mu     sync.RWMutex
+	kv     map[string]map[string][]byte
+	vector map[string]string
+}
+
+func NewInMemory() *InMemory {
+	return &InMemory{
+		kv:     map[string]map[string][]byte{},
+		vector: map[string]string{},
+	}
+}
+
+func (m *InMemory) Set(_ context.Context, bucket, key string, val []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.kv[bucket] == nil {
+		m.kv[bucket] = map[string][]byte{}
+	}
+	cp := make([]byte, len(val))
+	copy(cp, val)
+	m.kv[bucket][key] = cp
+	return nil
+}
+
+func (m *InMemory) Get(_ context.Context, bucket, key string) ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.kv[bucket] == nil {
+		return nil, nil
+	}
+	val, ok := m.kv[bucket][key]
+	if !ok {
+		return nil, nil
+	}
+	cp := make([]byte, len(val))
+	copy(cp, val)
+	return cp, nil
+}
+
+func (m *InMemory) Add(_ context.Context, id, text string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.vector[id] = text
+	return nil
+}
+
+func (m *InMemory) Query(_ context.Context, _ string, k int) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	ids := make([]string, 0, k)
+	for id := range m.vector {
+		ids = append(ids, id)
+		if len(ids) >= k {
+			break
+		}
+	}
+	return ids, nil
+}

--- a/tests/memstore_factory_test.go
+++ b/tests/memstore_factory_test.go
@@ -1,0 +1,36 @@
+package tests
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/marcodenic/agentry/pkg/memstore"
+)
+
+func TestStoreFactory(t *testing.T) {
+	tmp := t.TempDir()
+
+	s, err := memstore.StoreFactory("sqlite:" + filepath.Join(tmp, "db.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.(*memstore.SQLite); !ok {
+		t.Fatalf("expected SQLite, got %T", s)
+	}
+
+	s, err = memstore.StoreFactory("file:" + filepath.Join(tmp, "data.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.(*memstore.File); !ok {
+		t.Fatalf("expected File, got %T", s)
+	}
+
+	s, err = memstore.StoreFactory("mem:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.(*memstore.InMemory); !ok {
+		t.Fatalf("expected InMemory, got %T", s)
+	}
+}


### PR DESCRIPTION
## Summary
- add `StoreFactory` with `sqlite:`, `file:`, and `mem:` backends
- implement file and in-memory stores
- use the new factory in agent builder
- extend config loader for `memory:` field
- document memory config in README
- test the factory

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858914d71808320822ee0cc9503f74b