### PR TITLE
Introduce EventYield trace event

### DIFF
--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -91,7 +90,8 @@ func (a *Agent) Run(ctx context.Context, input string) (string, error) {
 		}
 		a.Mem.AddStep(step)
 	}
-	return "", errors.New("max iterations")
+	a.Trace(ctx, trace.EventYield, nil)
+	return "", nil
 }
 
 // SaveState persists the agent's memory under the given ID.

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -17,6 +17,8 @@ const (
 	EventToolEnd    EventType = "tool_end"
 	EventFinal      EventType = "final"
 	EventModelStart EventType = "model_start"
+	// EventYield signals that the agent stopped because the iteration limit was reached.
+	EventYield EventType = "yield"
 )
 
 type Event struct {

--- a/tests/agent_yield_test.go
+++ b/tests/agent_yield_test.go
@@ -1,0 +1,45 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/model"
+	"github.com/marcodenic/agentry/internal/router"
+	"github.com/marcodenic/agentry/internal/tool"
+	"github.com/marcodenic/agentry/internal/trace"
+)
+
+type loopMock struct{}
+
+func (loopMock) Complete(ctx context.Context, msgs []model.ChatMessage, tools []model.ToolSpec) (model.Completion, error) {
+	args, _ := json.Marshal(map[string]string{"text": "hi"})
+	return model.Completion{ToolCalls: []model.ToolCall{{ID: "1", Name: "echo", Arguments: args}}}, nil
+}
+
+type captureWriter struct{ events []trace.Event }
+
+func (c *captureWriter) Write(_ context.Context, e trace.Event) { c.events = append(c.events, e) }
+
+func TestAgentRunYields(t *testing.T) {
+	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: loopMock{}}}
+	cw := &captureWriter{}
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, cw)
+
+	out, err := ag.Run(context.Background(), "start")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "" {
+		t.Fatalf("expected empty output, got %s", out)
+	}
+	if len(cw.events) == 0 {
+		t.Fatal("no events captured")
+	}
+	if cw.events[len(cw.events)-1].Type != trace.EventYield {
+		t.Fatalf("expected yield event, got %v", cw.events[len(cw.events)-1].Type)
+	}
+}


### PR DESCRIPTION
## Summary
- add `EventYield` type for agent iteration yield tracing
- update `core.Agent.Run` to emit `EventYield` instead of erroring out
- test yielding when the iteration limit is hit

## Testing
- `go test ./...`
- `cd ts-sdk && npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68589152c8548320bc432e6235559600