### PR TITLE
Implement agent checkpointing

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ agentry flow .
 ```
 
 Pass `--resume-id name` to load a saved session and `--save-id name` to persist after each run.
+Use `--checkpoint-id name` to continuously snapshot the run loop and resume after a crash.
 
 The new `tui` command launches a split-screen interface:
 
@@ -214,7 +215,7 @@ Add a `store` path to your `.agentry.yaml` to enable persistence:
 store: path/to/db.sqlite
 ```
 
-Run the CLI with `--resume-id myrun` to load a snapshot before running and `--save-id myrun` to save state after each run.
+Run the CLI with `--resume-id myrun` to load a snapshot before running and `--save-id myrun` to save state after each run. `--checkpoint-id myrun` continuously saves intermediate steps so sessions can be resumed.
 
 ---
 

--- a/cmd/agentry/main.go
+++ b/cmd/agentry/main.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/marcodenic/agentry/internal/config"
 	"github.com/marcodenic/agentry/internal/converse"
@@ -40,6 +42,7 @@ func main() {
 	mcpFlag := fs.String("mcp", "", "comma-separated MCP servers")
 	saveID := fs.String("save-id", "", "save conversation state to this ID")
 	resumeID := fs.String("resume-id", "", "load conversation state from this ID")
+	ckptID := fs.String("checkpoint-id", "", "checkpoint session id")
 	_ = fs.Parse(args)
 	var configPath string
 	if *conf != "" {
@@ -60,8 +63,9 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		if *resumeID != "" {
-			_ = ag.LoadState(context.Background(), *resumeID)
+		if *ckptID != "" {
+			ag.ID = uuid.NewSHA1(uuid.NameSpaceOID, []byte(*ckptID))
+			_ = ag.Resume(context.Background())
 		}
 		if *resumeID != "" {
 			_ = ag.LoadState(context.Background(), *resumeID)
@@ -144,6 +148,10 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
+		if *ckptID != "" {
+			ag.ID = uuid.NewSHA1(uuid.NameSpaceOID, []byte(*ckptID))
+			_ = ag.Resume(context.Background())
+		}
 		if *resumeID != "" {
 			_ = ag.LoadState(context.Background(), *resumeID)
 		}
@@ -201,6 +209,10 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
+		if *ckptID != "" {
+			ag.ID = uuid.NewSHA1(uuid.NameSpaceOID, []byte(*ckptID))
+			_ = ag.Resume(context.Background())
+		}
 		suite := "tests/eval_suite.json"
 		if key != "" {
 			suite = "tests/openai_eval_suite.json"
@@ -257,6 +269,10 @@ func main() {
 		ag, err := buildAgent(cfg)
 		if err != nil {
 			panic(err)
+		}
+		if *ckptID != "" {
+			ag.ID = uuid.NewSHA1(uuid.NameSpaceOID, []byte(*ckptID))
+			_ = ag.Resume(context.Background())
 		}
 		if *resumeID != "" {
 			_ = ag.LoadState(context.Background(), *resumeID)

--- a/tests/agent_checkpoint_test.go
+++ b/tests/agent_checkpoint_test.go
@@ -1,0 +1,44 @@
+package tests
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/router"
+	"github.com/marcodenic/agentry/pkg/memstore"
+)
+
+func TestAgentCheckpointResume(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "mem.db")
+	store, err := memstore.NewSQLite(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: recordClient{}}}
+	ag := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag.ID = uuid.New()
+
+	if _, err := ag.Run(context.Background(), "hi"); err != nil {
+		t.Fatal(err)
+	}
+
+	ag2 := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag2.ID = ag.ID
+	if err := ag2.Resume(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	hist := ag2.Mem.History()
+	if len(hist) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(hist))
+	}
+	if hist[0].Output != "hello" {
+		t.Fatalf("unexpected output %s", hist[0].Output)
+	}
+}


### PR DESCRIPTION
## Summary
- save loop state with `Agent.Checkpoint`
- resume loop state with `Agent.Resume`
- persist checkpoints after each event
- allow CLI `--checkpoint-id`
- document new option
- test checkpoint/resume logic

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685891516af08320b1c5f09fc98fb730