### PR TITLE
Add CRI shim runner

### DIFF
--- a/examples/.agentry.yaml
+++ b/examples/.agentry.yaml
@@ -59,6 +59,7 @@ tools:
   - name: local_shell
     command: echo hello
     description: Uses shell (optional, advanced)
+    engine: cri
 metrics: true
 # path to SQLite DB for conversation history
 # store: path/to/db.sqlite

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -19,6 +19,7 @@ type ToolManifest struct {
 	Net         string         `yaml:"net,omitempty" json:"net,omitempty"`
 	CPULimit    string         `yaml:"cpu_limit,omitempty" json:"cpu_limit,omitempty"`
 	MemLimit    string         `yaml:"mem_limit,omitempty" json:"mem_limit,omitempty"`
+	Engine      string         `yaml:"engine,omitempty" json:"engine,omitempty"`
 }
 
 type ModelManifest struct {

--- a/internal/tool/manifest.go
+++ b/internal/tool/manifest.go
@@ -571,6 +571,7 @@ func FromManifest(m config.ToolManifest) (Tool, error) {
 		return NewWithSchema(m.Name, m.Description, map[string]any{"type": "object", "properties": map[string]any{}}, func(ctx context.Context, args map[string]any) (string, error) {
 			if !m.Privileged {
 				return sbox.Exec(ctx, m.Command, sbox.Options{
+					Engine:   m.Engine,
 					Net:      m.Net,
 					CPULimit: m.CPULimit,
 					MemLimit: m.MemLimit,

--- a/pkg/sbox/sbox.go
+++ b/pkg/sbox/sbox.go
@@ -8,7 +8,7 @@ import (
 
 // Options controls sandboxed execution.
 type Options struct {
-	Engine   string // "docker" or "gvisor"
+	Engine   string // "docker", "gvisor", or "cri"
 	Net      string
 	CPULimit string
 	MemLimit string
@@ -51,6 +51,8 @@ func buildArgs(engine, cmdStr string, opts Options) []string {
 		return args
 	case "gvisor":
 		return []string{"runsc", "bash", "-c", cmdStr}
+	case "cri":
+		return []string{"cri-shim", "run", "--", "sh", "-c", cmdStr}
 	default:
 		return nil
 	}

--- a/tests/agent_checkpoint_test.go
+++ b/tests/agent_checkpoint_test.go
@@ -21,14 +21,14 @@ func TestAgentCheckpointResume(t *testing.T) {
 	defer store.Close()
 
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: recordClient{}}}
-	ag := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag.ID = uuid.New()
 
 	if _, err := ag.Run(context.Background(), "hi"); err != nil {
 		t.Fatal(err)
 	}
 
-	ag2 := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag2 := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag2.ID = ag.ID
 	if err := ag2.Resume(context.Background()); err != nil {
 		t.Fatal(err)

--- a/tests/agent_yield_test.go
+++ b/tests/agent_yield_test.go
@@ -27,7 +27,7 @@ func (c *captureWriter) Write(_ context.Context, e trace.Event) { c.events = app
 func TestAgentRunYields(t *testing.T) {
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: loopMock{}}}
 	cw := &captureWriter{}
-	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, cw)
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), cw)
 
 	out, err := ag.Run(context.Background(), "start")
 	if err != nil {

--- a/tests/sandbox_test.go
+++ b/tests/sandbox_test.go
@@ -59,3 +59,28 @@ func TestSandboxGVisor(t *testing.T) {
 		t.Fatalf("got %v want %v", got, want)
 	}
 }
+
+func TestSandboxCRI(t *testing.T) {
+	var got []string
+	sbox.RunCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		got = append([]string{name}, args...)
+		return exec.CommandContext(ctx, "echo", "ok")
+	}
+	defer func() {
+		sbox.RunCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, name, args...)
+		}
+	}()
+
+	out, err := sbox.Exec(context.Background(), "echo hi", sbox.Options{Engine: "cri"})
+	if err != nil {
+		t.Fatalf("exec failed: %v", err)
+	}
+	if strings.TrimSpace(out) != "ok" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+	want := []string{"cri-shim", "run", "--", "sh", "-c", "echo hi"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add 'cri' sandbox engine
- pass engine via ToolManifest
- update example config
- expand sandbox and manifest tests
- fix agent checkpoint/yield tests to new core API

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685897aa122c8320b77c22c9e5283643