### PR TITLE
Add example flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Example:
 agentry flow .
 ```
 
+Run the sample scenarios in `examples/flows`:
+
+```bash
+agentry flow examples/flows/research_task
+agentry flow examples/flows/etl_pipeline
+agentry flow examples/flows/multi_agent_chat
+```
+
 Pass `--resume-id name` to load a saved session and `--save-id name` to persist after each run.
 Use `--checkpoint-id name` to continuously snapshot the run loop and resume after a crash.
 

--- a/examples/flows/etl_pipeline/.agentry.flow.yaml
+++ b/examples/flows/etl_pipeline/.agentry.flow.yaml
@@ -1,0 +1,12 @@
+agents:
+  planner:
+    model: mock
+  executor:
+    model: mock
+    tools: [bash]
+tasks:
+  - sequential:
+      - agent: planner
+        input: "Explain how to convert CSV data to JSON using shell utilities."
+      - agent: executor
+        input: "Create a script that converts sample.csv to sample.json."

--- a/examples/flows/multi_agent_chat/.agentry.flow.yaml
+++ b/examples/flows/multi_agent_chat/.agentry.flow.yaml
@@ -1,0 +1,15 @@
+agents:
+  alice:
+    model: mock
+  bob:
+    model: mock
+  carol:
+    model: mock
+tasks:
+  - parallel:
+      - agent: alice
+        input: "Propose a project idea."
+      - agent: bob
+        input: "Provide feedback on the idea."
+      - agent: carol
+        input: "Summarise the discussion."

--- a/examples/flows/research_task/.agentry.flow.yaml
+++ b/examples/flows/research_task/.agentry.flow.yaml
@@ -1,0 +1,10 @@
+agents:
+  researcher:
+    model: mock
+    tools: [fetch, view]
+tasks:
+  - sequential:
+      - agent: researcher
+        input: "Gather sources about the Go programming language."
+      - agent: researcher
+        input: "Summarise the key features of Go."

--- a/tests/agent_checkpoint_test.go
+++ b/tests/agent_checkpoint_test.go
@@ -21,14 +21,14 @@ func TestAgentCheckpointResume(t *testing.T) {
 	defer store.Close()
 
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: recordClient{}}}
-	ag := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag.ID = uuid.New()
 
 	if _, err := ag.Run(context.Background(), "hi"); err != nil {
 		t.Fatal(err)
 	}
 
-	ag2 := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag2 := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag2.ID = ag.ID
 	if err := ag2.Resume(context.Background()); err != nil {
 		t.Fatal(err)

--- a/tests/agent_yield_test.go
+++ b/tests/agent_yield_test.go
@@ -27,7 +27,7 @@ func (c *captureWriter) Write(_ context.Context, e trace.Event) { c.events = app
 func TestAgentRunYields(t *testing.T) {
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: loopMock{}}}
 	cw := &captureWriter{}
-	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, cw)
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), cw)
 
 	out, err := ag.Run(context.Background(), "start")
 	if err != nil {

--- a/tests/flow_engine_test.go
+++ b/tests/flow_engine_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/marcodenic/agentry/internal/tool"
@@ -56,6 +57,19 @@ func TestFlowEngineParallel(t *testing.T) {
 	for _, o := range outs {
 		if o != "hello" {
 			t.Fatalf("unexpected output %s", o)
+		}
+	}
+}
+
+func TestLoadExampleFlows(t *testing.T) {
+	cases := []string{
+		filepath.Join("..", "examples", "flows", "research_task"),
+		filepath.Join("..", "examples", "flows", "etl_pipeline"),
+		filepath.Join("..", "examples", "flows", "multi_agent_chat"),
+	}
+	for _, dir := range cases {
+		if _, err := flow.Load(dir); err != nil {
+			t.Fatalf("failed to load %s: %v", dir, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add three sample `.agentry.flow.yaml` scenarios
- document how to run them with `agentry flow`
- load the example flows in tests
- fix tests after `core.New` signature change

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685897c614448320a5f1e45fa8898687