### PR TITLE
Add role templates and include support

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,38 @@ vector_store:
 
 Supported types are `qdrant`, `faiss`, and the default in-memory store.
 
+### ♻️ Reusing Roles
+
+Role templates live under `templates/roles/`. Each YAML file defines an agent
+name, prompt, and allowed tools:
+
+```yaml
+name: coder
+prompt: |
+  You are an expert software developer.
+tools:
+  - bash
+  - patch
+```
+
+Reference templates from a flow using the `include` key:
+
+```yaml
+include:
+  - templates/roles/coder.yaml
+
+agents:
+  coder:
+    model: gpt-4o
+
+tasks:
+  - agent: coder
+    input: build a CLI
+```
+
+The template's prompt and tools merge with the agent definition. Paths are
+resolved relative to the flow file.
+
 ---
 
 ## ⚙️ Environment Configuration

--- a/templates/roles/coder.yaml
+++ b/templates/roles/coder.yaml
@@ -1,0 +1,7 @@
+name: coder
+prompt: |
+  You are an expert software developer who writes clear, concise code.
+tools:
+  - bash
+  - patch
+  - view

--- a/templates/roles/writer.yaml
+++ b/templates/roles/writer.yaml
@@ -1,0 +1,7 @@
+name: writer
+prompt: |
+  You craft engaging prose and explain complex topics clearly.
+tools:
+  - fetch
+  - write
+  - view

--- a/tests/agent_checkpoint_test.go
+++ b/tests/agent_checkpoint_test.go
@@ -21,14 +21,14 @@ func TestAgentCheckpointResume(t *testing.T) {
 	defer store.Close()
 
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: recordClient{}}}
-	ag := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag.ID = uuid.New()
 
 	if _, err := ag.Run(context.Background(), "hi"); err != nil {
 		t.Fatal(err)
 	}
 
-	ag2 := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag2 := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag2.ID = ag.ID
 	if err := ag2.Resume(context.Background()); err != nil {
 		t.Fatal(err)

--- a/tests/agent_yield_test.go
+++ b/tests/agent_yield_test.go
@@ -27,7 +27,7 @@ func (c *captureWriter) Write(_ context.Context, e trace.Event) { c.events = app
 func TestAgentRunYields(t *testing.T) {
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: loopMock{}}}
 	cw := &captureWriter{}
-	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, cw)
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), cw)
 
 	out, err := ag.Run(context.Background(), "start")
 	if err != nil {

--- a/tests/flow_parser_test.go
+++ b/tests/flow_parser_test.go
@@ -44,3 +44,39 @@ tasks:
 		t.Fatalf("expected error for undefined agent")
 	}
 }
+
+func TestFlowParseInclude(t *testing.T) {
+	dir := t.TempDir()
+	role := `name: coder
+prompt: |
+  testing role
+tools:
+  - bash
+`
+	if err := os.WriteFile(filepath.Join(dir, "role.yaml"), []byte(role), 0644); err != nil {
+		t.Fatal(err)
+	}
+	flowYaml := `include:
+  - role.yaml
+agents:
+  coder:
+    model: mock
+tasks:
+  - agent: coder
+    input: hi
+`
+	if err := os.WriteFile(filepath.Join(dir, ".agentry.flow.yaml"), []byte(flowYaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := flow.Load(dir)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	ag, ok := f.Agents["coder"]
+	if !ok {
+		t.Fatalf("agent not loaded")
+	}
+	if ag.Prompt == "" || len(ag.Tools) != 1 || ag.Tools[0] != "bash" {
+		t.Fatalf("include failed: %#v", ag)
+	}
+}


### PR DESCRIPTION
## Summary
- add example role definitions under `templates/roles`
- enable `include:` syntax in flow parser to merge role templates
- document how to reuse roles with the new directory
- update tests for the new loader behaviour

## Testing
- `go test ./...`
- `cd ts-sdk && npm install --legacy-peer-deps && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685897f3a2948320b6bbaf9ee975eead