### PR TITLE
Add Mustache variable support for agents

### DIFF
--- a/internal/core/template.go
+++ b/internal/core/template.go
@@ -1,0 +1,30 @@
+package core
+
+import "strings"
+
+func applyVars(s string, vars map[string]string) string {
+	for k, v := range vars {
+		s = strings.ReplaceAll(s, "{{"+k+"}}", v)
+	}
+	return s
+}
+
+func applyVarsMap(m map[string]any, vars map[string]string) {
+	for k, v := range m {
+		switch t := v.(type) {
+		case string:
+			m[k] = applyVars(t, vars)
+		case map[string]any:
+			applyVarsMap(t, vars)
+		case []any:
+			for i, elem := range t {
+				switch e := elem.(type) {
+				case string:
+					t[i] = applyVars(e, vars)
+				case map[string]any:
+					applyVarsMap(e, vars)
+				}
+			}
+		}
+	}
+}

--- a/pkg/flow/engine.go
+++ b/pkg/flow/engine.go
@@ -50,6 +50,8 @@ func Run(ctx context.Context, f *File, reg tool.Registry, store memstore.KV) ([]
 		}
 		route := router.Rules{{Name: conf.Model, IfContains: []string{""}, Client: client}}
 		ag := core.New(route, tools, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
+		ag.Prompt = conf.Prompt
+		ag.Vars = conf.Vars
 		return ag, nil
 	}
 

--- a/pkg/flow/parser.go
+++ b/pkg/flow/parser.go
@@ -18,6 +18,7 @@ type Agent struct {
 	Model  string            `yaml:"model"`
 	Prompt string            `yaml:"prompt,omitempty"`
 	Tools  []string          `yaml:"tools,omitempty"`
+	Vars   map[string]string `yaml:"vars,omitempty"`
 	Env    map[string]string `yaml:"env,omitempty"`
 }
 

--- a/tests/agent_checkpoint_test.go
+++ b/tests/agent_checkpoint_test.go
@@ -21,14 +21,14 @@ func TestAgentCheckpointResume(t *testing.T) {
 	defer store.Close()
 
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: recordClient{}}}
-	ag := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag.ID = uuid.New()
 
 	if _, err := ag.Run(context.Background(), "hi"); err != nil {
 		t.Fatal(err)
 	}
 
-	ag2 := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag2 := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag2.ID = ag.ID
 	if err := ag2.Resume(context.Background()); err != nil {
 		t.Fatal(err)

--- a/tests/agent_yield_test.go
+++ b/tests/agent_yield_test.go
@@ -27,7 +27,7 @@ func (c *captureWriter) Write(_ context.Context, e trace.Event) { c.events = app
 func TestAgentRunYields(t *testing.T) {
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: loopMock{}}}
 	cw := &captureWriter{}
-	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, cw)
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), cw)
 
 	out, err := ag.Run(context.Background(), "start")
 	if err != nil {

--- a/tests/flow_parser_test.go
+++ b/tests/flow_parser_test.go
@@ -13,6 +13,8 @@ func TestFlowParseSuccess(t *testing.T) {
 	yaml := `agents:
   coder:
     model: gpt-4
+    vars:
+      tone: excited
 tasks:
   - agent: coder
     input: build
@@ -26,6 +28,9 @@ tasks:
 	}
 	if len(f.Agents) != 1 || len(f.Tasks) != 1 {
 		t.Fatalf("unexpected parsed data: %#v", f)
+	}
+	if f.Agents["coder"].Vars["tone"] != "excited" {
+		t.Fatalf("vars not parsed: %#v", f.Agents["coder"].Vars)
 	}
 }
 

--- a/tests/prompt_vars_test.go
+++ b/tests/prompt_vars_test.go
@@ -1,0 +1,64 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/model"
+	"github.com/marcodenic/agentry/internal/router"
+	"github.com/marcodenic/agentry/internal/tool"
+)
+
+type promptCheckClient struct{ t *testing.T }
+
+func (p promptCheckClient) Complete(ctx context.Context, msgs []model.ChatMessage, tools []model.ToolSpec) (model.Completion, error) {
+	if !strings.Contains(msgs[0].Content, "cheerful") {
+		p.t.Fatalf("prompt not substituted: %s", msgs[0].Content)
+	}
+	return model.Completion{Content: "done"}, nil
+}
+
+func TestPromptVarSubstitution(t *testing.T) {
+	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: promptCheckClient{t}}}
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), nil)
+	ag.Prompt = "You are a {{tone}} bot"
+	ag.Vars = map[string]string{"tone": "cheerful"}
+	if _, err := ag.Run(context.Background(), "hi"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type argSubClient struct{ call int }
+
+func (a *argSubClient) Complete(ctx context.Context, msgs []model.ChatMessage, tools []model.ToolSpec) (model.Completion, error) {
+	a.call++
+	if a.call == 1 {
+		args, _ := json.Marshal(map[string]string{"text": "{{greet}} world"})
+		return model.Completion{ToolCalls: []model.ToolCall{{ID: "1", Name: "echo", Arguments: args}}}, nil
+	}
+	return model.Completion{Content: "ok"}, nil
+}
+
+func TestToolArgVarSubstitution(t *testing.T) {
+	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: &argSubClient{}}}
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), nil)
+	ag.Vars = map[string]string{"greet": "hello"}
+	out, err := ag.Run(context.Background(), "start")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "ok" {
+		t.Fatalf("unexpected final output %s", out)
+	}
+	hist := ag.Mem.History()
+	if len(hist) == 0 {
+		t.Fatal("no history recorded")
+	}
+	if res := hist[0].ToolResults["1"]; res != "hello world" {
+		t.Fatalf("args not substituted, got %s", res)
+	}
+}


### PR DESCRIPTION
## Summary
- implement simple Mustache-style substitution for prompts and tool args
- allow defining `vars` per agent in `.agentry.flow.yaml`
- wire prompt and vars into the flow engine
- update core agent to apply variables when building prompts and executing tools
- add tests for parser, prompt and argument substitution, and update existing tests

## Testing
- `go test ./...`
- `cd ts-sdk && npm install >/tmp/npm.log && npm test >/tmp/npm-test.log`


------
https://chatgpt.com/codex/tasks/task_e_685897fba9888320be4e5260669350b3