### PR TITLE
Add spawn/kill endpoints

### DIFF
--- a/README-cloud.md
+++ b/README-cloud.md
@@ -51,3 +51,44 @@ npm run build
 ```
 
 The build output in `ui/web/dist` is embedded into the hub and served at `/` when running `agentry serve --metrics`.
+
+## HTTP API
+
+Agentry exposes a simple JSON API. Agents are identified by UUIDs which map to
+persistent state in the configured `memstore` backend.
+
+### `POST /spawn`
+
+Create a new agent from the `default` template. Returns the assigned `agent_id`.
+
+```
+curl -X POST http://localhost:8080/spawn
+```
+
+Response:
+
+```json
+{"agent_id": "<uuid>"}
+```
+
+### `POST /invoke`
+
+Send a message to an agent. Set `stream` to `true` for an SSE stream.
+
+```json
+{
+  "agent_id": "<uuid>",
+  "input": "hello",
+  "stream": false
+}
+```
+
+### `POST /kill`
+
+Persist the agent's state and remove it from memory.
+
+```json
+{
+  "agent_id": "<uuid>"
+}
+```

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/marcodenic/agentry/internal/core"
 	"github.com/marcodenic/agentry/internal/trace"
 	"github.com/marcodenic/agentry/ui"
@@ -17,6 +18,42 @@ func Handler(agents map[string]*core.Agent, metrics bool, saveID, resumeID strin
 		mux.Handle("/metrics", promhttp.Handler())
 	}
 	mux.Handle("/", http.FileServer(http.FS(ui.WebUI)))
+	mux.HandleFunc("/spawn", func(w http.ResponseWriter, r *http.Request) {
+		var in struct {
+			Template string `json:"template"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		if in.Template == "" {
+			in.Template = "default"
+		}
+		base := agents[in.Template]
+		if base == nil {
+			http.Error(w, "unknown template", http.StatusBadRequest)
+			return
+		}
+		ag := base.Spawn()
+		id := uuid.New().String()
+		ag.ID = uuid.MustParse(id)
+		agents[id] = ag
+		_ = json.NewEncoder(w).Encode(map[string]string{"agent_id": id})
+	})
+	mux.HandleFunc("/kill", func(w http.ResponseWriter, r *http.Request) {
+		var in struct {
+			AgentID string `json:"agent_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+		ag := agents[in.AgentID]
+		if ag == nil {
+			http.Error(w, "unknown agent", http.StatusBadRequest)
+			return
+		}
+		_ = ag.SaveState(r.Context(), in.AgentID)
+		delete(agents, in.AgentID)
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	})
 	mux.HandleFunc("/invoke", func(w http.ResponseWriter, r *http.Request) {
 		var in struct {
 			AgentID string `json:"agent_id"`
@@ -27,12 +64,16 @@ func Handler(agents map[string]*core.Agent, metrics bool, saveID, resumeID strin
 			http.Error(w, "bad json", http.StatusBadRequest)
 			return
 		}
-		base := agents[in.AgentID]
-		if base == nil {
+		ag := agents[in.AgentID]
+		if ag == nil {
 			http.Error(w, "unknown agent", http.StatusBadRequest)
 			return
 		}
-		ag := base.Spawn()
+		if in.AgentID == "default" {
+			ag = ag.Spawn()
+		} else {
+			_ = ag.Resume(r.Context())
+		}
 		if in.Stream {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.Header().Set("Cache-Control", "no-cache")
@@ -46,7 +87,7 @@ func Handler(agents map[string]*core.Agent, metrics bool, saveID, resumeID strin
 			}
 			return
 		}
-		if resumeID != "" {
+		if in.AgentID == "default" && resumeID != "" {
 			_ = ag.LoadState(r.Context(), resumeID)
 		}
 		out, err := ag.Run(r.Context(), in.Input)
@@ -54,7 +95,7 @@ func Handler(agents map[string]*core.Agent, metrics bool, saveID, resumeID strin
 			http.Error(w, err.Error(), 500)
 			return
 		}
-		if saveID != "" {
+		if in.AgentID == "default" && saveID != "" {
 			_ = ag.SaveState(r.Context(), saveID)
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"output": out})

--- a/tests/agent_checkpoint_test.go
+++ b/tests/agent_checkpoint_test.go
@@ -21,14 +21,14 @@ func TestAgentCheckpointResume(t *testing.T) {
 	defer store.Close()
 
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: recordClient{}}}
-	ag := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag.ID = uuid.New()
 
 	if _, err := ag.Run(context.Background(), "hi"); err != nil {
 		t.Fatal(err)
 	}
 
-	ag2 := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag2 := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag2.ID = ag.ID
 	if err := ag2.Resume(context.Background()); err != nil {
 		t.Fatal(err)

--- a/tests/agent_yield_test.go
+++ b/tests/agent_yield_test.go
@@ -27,7 +27,7 @@ func (c *captureWriter) Write(_ context.Context, e trace.Event) { c.events = app
 func TestAgentRunYields(t *testing.T) {
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: loopMock{}}}
 	cw := &captureWriter{}
-	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, cw)
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), cw)
 
 	out, err := ag.Run(context.Background(), "start")
 	if err != nil {

--- a/tests/server_spawn_kill_test.go
+++ b/tests/server_spawn_kill_test.go
@@ -1,0 +1,86 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/model"
+	"github.com/marcodenic/agentry/internal/router"
+	"github.com/marcodenic/agentry/internal/server"
+	"github.com/marcodenic/agentry/internal/tool"
+	"github.com/marcodenic/agentry/pkg/memstore"
+)
+
+func TestServerSpawnKill(t *testing.T) {
+	store := memstore.NewInMemory()
+	route := router.Rules{{IfContains: []string{""}, Client: model.NewMock()}}
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
+	agents := map[string]*core.Agent{"default": ag}
+
+	srv := httptest.NewServer(server.Handler(agents, false, "", ""))
+	defer srv.Close()
+
+	// spawn a new agent
+	resp, err := http.Post(srv.URL+"/spawn", "application/json", bytes.NewBufferString("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var out struct {
+		AgentID string `json:"agent_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := uuid.Parse(out.AgentID); err != nil {
+		t.Fatalf("bad uuid %s", out.AgentID)
+	}
+
+	// invoke the agent
+	body := fmt.Sprintf(`{"agent_id":"%s","input":"hi"}`, out.AgentID)
+	resp2, err := http.Post(srv.URL+"/invoke", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	var res struct {
+		Output string `json:"output"`
+	}
+	if err := json.NewDecoder(resp2.Body).Decode(&res); err != nil {
+		t.Fatal(err)
+	}
+	if res.Output == "" {
+		t.Fatalf("empty output")
+	}
+
+	// kill the agent
+	killBody := fmt.Sprintf(`{"agent_id":"%s"}`, out.AgentID)
+	resp3, err := http.Post(srv.URL+"/kill", "application/json", bytes.NewBufferString(killBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp3.Body.Close()
+
+	// should no longer exist
+	resp4, err := http.Post(srv.URL+"/invoke", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp4.StatusCode == http.StatusOK {
+		t.Fatal("expected error for missing agent")
+	}
+
+	// persisted history should be stored
+	b, err := store.Get(context.Background(), "history", out.AgentID)
+	if err != nil || b == nil {
+		t.Fatalf("state not saved: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `/spawn` and `/kill` HTTP endpoints to manage agents
- persist agent state in memstore using UUID keys
- document the API in `README-cloud.md`
- test spawn/kill functionality

## Testing
- `go test ./...`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685897e0c5a08320b06eeedf6a54b602