### PR TITLE
Add tool init scaffolding command

### DIFF
--- a/cmd/agentry/main.go
+++ b/cmd/agentry/main.go
@@ -297,6 +297,8 @@ func main() {
 		}
 	case "plugin":
 		runPluginCmd(args)
+	case "tool":
+		runToolCmd(args)
 	default:
 		fmt.Println("unknown command. Usage: agentry [dev|serve|tui|eval|flow] [--config path/to/config.yaml]")
 		os.Exit(1)

--- a/cmd/agentry/plugin.go
+++ b/cmd/agentry/plugin.go
@@ -27,3 +27,24 @@ func runPluginCmd(args []string) {
 		os.Exit(1)
 	}
 }
+
+func runToolCmd(args []string) {
+	if len(args) == 0 {
+		fmt.Println("Usage: agentry tool <command> [args]")
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "init":
+		if len(args) < 2 {
+			fmt.Println("Usage: agentry tool init <name>")
+			os.Exit(1)
+		}
+		if err := plugin.InitTool(args[1]); err != nil {
+			fmt.Printf("init failed: %v\n", err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Printf("unknown tool command %s\n", args[0])
+		os.Exit(1)
+	}
+}

--- a/internal/plugin/init.go
+++ b/internal/plugin/init.go
@@ -1,0 +1,47 @@
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// InitTool scaffolds a builtin tool plugin in a new directory named after the tool.
+func InitTool(name string) error {
+	if name == "" {
+		return fmt.Errorf("tool name required")
+	}
+	if err := os.MkdirAll(name, 0755); err != nil {
+		return err
+	}
+	goFile := filepath.Join(name, name+".go")
+	yamlFile := filepath.Join(name, name+".yaml")
+
+	goSrc := fmt.Sprintf(`package %s
+
+import (
+    "context"
+
+    "github.com/marcodenic/agentry/internal/tool"
+)
+
+func init() {
+    tool.Register("%s", "%s tool", nil, Exec)
+}
+
+// Exec executes the %s tool.
+func Exec(ctx context.Context, args map[string]any) (string, error) {
+    return "", nil
+}
+`, name, name, name, name)
+
+	yamlSrc := fmt.Sprintf("name: %s\ndescription: %s tool\ntype: builtin\n", name, name)
+
+	if err := os.WriteFile(goFile, []byte(goSrc), 0644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(yamlFile, []byte(yamlSrc), 0644); err != nil {
+		return err
+	}
+	return nil
+}

--- a/tests/agent_checkpoint_test.go
+++ b/tests/agent_checkpoint_test.go
@@ -21,14 +21,14 @@ func TestAgentCheckpointResume(t *testing.T) {
 	defer store.Close()
 
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: recordClient{}}}
-	ag := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag.ID = uuid.New()
 
 	if _, err := ag.Run(context.Background(), "hi"); err != nil {
 		t.Fatal(err)
 	}
 
-	ag2 := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag2 := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag2.ID = ag.ID
 	if err := ag2.Resume(context.Background()); err != nil {
 		t.Fatal(err)

--- a/tests/agent_yield_test.go
+++ b/tests/agent_yield_test.go
@@ -27,7 +27,7 @@ func (c *captureWriter) Write(_ context.Context, e trace.Event) { c.events = app
 func TestAgentRunYields(t *testing.T) {
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: loopMock{}}}
 	cw := &captureWriter{}
-	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, cw)
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), cw)
 
 	out, err := ag.Run(context.Background(), "start")
 	if err != nil {

--- a/tests/tool_init_test.go
+++ b/tests/tool_init_test.go
@@ -1,0 +1,40 @@
+package tests
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/plugin"
+)
+
+func TestToolInitScaffold(t *testing.T) {
+	dir := t.TempDir()
+	cwd, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(cwd)
+
+	if err := plugin.InitTool("demo"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	goFile := filepath.Join("demo", "demo.go")
+	yamlFile := filepath.Join("demo", "demo.yaml")
+
+	if _, err := os.Stat(goFile); err != nil {
+		t.Fatalf("missing go file: %v", err)
+	}
+	if _, err := os.Stat(yamlFile); err != nil {
+		t.Fatalf("missing yaml file: %v", err)
+	}
+
+	gb, _ := os.ReadFile(goFile)
+	if !bytes.Contains(gb, []byte("func Exec")) {
+		t.Fatalf("exec function not found")
+	}
+	yb, _ := os.ReadFile(yamlFile)
+	if !bytes.Contains(yb, []byte("name: demo")) {
+		t.Fatalf("name not written")
+	}
+}


### PR DESCRIPTION
## Summary
- support `agentry tool init <name>` command
- scaffold plugin source and manifest
- fix tests after agent constructor update
- cover tool scaffolding logic with tests

## Testing
- `go test ./...`
- `npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68589805212083209e147f28b76e7d68