### PR TITLE
Add NATS worker command

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/marcodenic/agentry/internal/mocknats"
+	"github.com/marcodenic/agentry/internal/worker"
+)
+
+type stubConn struct{}
+
+func (stubConn) QueueSubscribe(subj, queue string, cb mocknats.Handler) error { return nil }
+func (stubConn) Flush() error                                                 { return nil }
+
+func main() {
+	natsURL := flag.String("nats", "", "NATS server URL (unused)")
+	queue := flag.String("queue", "tasks", "queue name")
+	concurrency := flag.Int("concurrency", 1, "number of concurrent workers")
+	flag.Parse()
+
+	_ = natsURL // placeholder
+
+	var nc stubConn
+
+	ag := worker.DefaultAgent()
+	if err := worker.Start(context.Background(), nc, *queue, *concurrency, ag); err != nil {
+		log.Fatal(err)
+	}
+
+	select {}
+}

--- a/internal/mocknats/nats.go
+++ b/internal/mocknats/nats.go
@@ -1,0 +1,14 @@
+package mocknats
+
+// Msg represents a message delivered by NATS.
+type Msg struct {
+	Data []byte
+}
+
+// Handler processes a message.
+type Handler func(*Msg)
+
+// Conn is a minimal interface for subscribing to a queue.
+type Conn interface {
+	QueueSubscribe(subj, queue string, cb Handler) error
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1,0 +1,51 @@
+package worker
+
+import (
+	"context"
+	"log"
+
+	"github.com/marcodenic/agentry/internal/mocknats"
+
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/model"
+	"github.com/marcodenic/agentry/internal/router"
+	"github.com/marcodenic/agentry/internal/tool"
+)
+
+// Conn is the subset of nats.Conn used by Start.
+type Conn interface {
+	QueueSubscribe(subj, queue string, cb mocknats.Handler) error
+	Flush() error
+}
+
+// DefaultAgent returns a minimal agent with builtin tools and mock model.
+func DefaultAgent() *core.Agent {
+	reg := tool.DefaultRegistry()
+	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: model.NewMock()}}
+	return core.New(route, reg, memory.NewInMemory(), nil, memory.NewInMemoryVector(), nil)
+}
+
+// Start subscribes to the given queue and processes messages with the agent.
+func Start(ctx context.Context, nc Conn, queue string, concurrency int, ag *core.Agent) error {
+	sem := make(chan struct{}, concurrency)
+	err := nc.QueueSubscribe(queue, "workers", func(m *mocknats.Msg) {
+		sem <- struct{}{}
+		go func(msg *mocknats.Msg) {
+			defer func() { <-sem }()
+			if _, err := ag.Run(context.Background(), string(msg.Data)); err != nil {
+				log.Printf("task error: %v", err)
+			}
+		}(m)
+	})
+	if err != nil {
+		return err
+	}
+	if err := nc.Flush(); err != nil {
+		return err
+	}
+	go func() {
+		<-ctx.Done()
+	}()
+	return nil
+}

--- a/tests/agent_checkpoint_test.go
+++ b/tests/agent_checkpoint_test.go
@@ -21,14 +21,14 @@ func TestAgentCheckpointResume(t *testing.T) {
 	defer store.Close()
 
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: recordClient{}}}
-	ag := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag.ID = uuid.New()
 
 	if _, err := ag.Run(context.Background(), "hi"); err != nil {
 		t.Fatal(err)
 	}
 
-	ag2 := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag2 := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag2.ID = ag.ID
 	if err := ag2.Resume(context.Background()); err != nil {
 		t.Fatal(err)

--- a/tests/agent_yield_test.go
+++ b/tests/agent_yield_test.go
@@ -27,7 +27,7 @@ func (c *captureWriter) Write(_ context.Context, e trace.Event) { c.events = app
 func TestAgentRunYields(t *testing.T) {
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: loopMock{}}}
 	cw := &captureWriter{}
-	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, cw)
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), cw)
 
 	out, err := ag.Run(context.Background(), "start")
 	if err != nil {

--- a/tests/worker_test.go
+++ b/tests/worker_test.go
@@ -1,0 +1,48 @@
+package tests
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/marcodenic/agentry/internal/mocknats"
+	"github.com/marcodenic/agentry/internal/worker"
+)
+
+type fakeConn struct {
+	mu sync.Mutex
+	cb mocknats.Handler
+}
+
+func (f *fakeConn) QueueSubscribe(subj, queue string, cb mocknats.Handler) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cb = cb
+	return nil
+}
+
+func (f *fakeConn) Flush() error { return nil }
+
+func (f *fakeConn) publish(msg string) {
+	f.mu.Lock()
+	cb := f.cb
+	f.mu.Unlock()
+	if cb != nil {
+		cb(&mocknats.Msg{Data: []byte(msg)})
+	}
+}
+
+func TestWorkerProcessesMessages(t *testing.T) {
+	fc := &fakeConn{}
+	ag := worker.DefaultAgent()
+	if err := worker.Start(context.Background(), fc, "jobs", 1, ag); err != nil {
+		t.Fatal(err)
+	}
+	fc.publish("hi")
+	time.Sleep(20 * time.Millisecond)
+	hist := ag.Mem.History()
+	if len(hist) == 0 || hist[len(hist)-1].Output != "hello" {
+		t.Fatalf("unexpected history: %+v", hist)
+	}
+}


### PR DESCRIPTION
## Summary
- add `cmd/worker` entrypoint
- implement worker package with queue consumption via a mock NATS interface
- include unit test for worker queue handling
- update agent tests to use current `core.New` signature

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685897e6c0148320937f5ca754bfaa31