### PR TITLE
Add plugin registry docs and GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,31 @@
+name: Deploy Registry
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/registry/**'
+      - '.github/workflows/pages.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/registry
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For the upcoming cloud deployment model, see [README-cloud.md](./README-cloud.md
 | ⚙️ **Config**        | `.agentry.yaml` bootstraps agent, models, tools          |
 | 🧪 **Evaluation**    | YAML test suites, CLI `agentry eval`                     |
 | 🛠️ **SDK**           | JS/TS client (`@marcodenic/agentry`), supports streaming |
+| 📦 **Registry**     | [Plugin Registry](docs/registry/) |
 
 ---
 

--- a/docs/registry/index.html
+++ b/docs/registry/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Agentry Plugin Registry</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; }
+    h1 { color: #333; }
+    ul { list-style: none; padding: 0; }
+    li { margin-bottom: 1rem; }
+    .name { font-weight: bold; }
+  </style>
+</head>
+<body>
+  <h1>Agentry Plugin Registry</h1>
+  <p>Browse available plugins for the Agentry runtime. Submit a PR to update this list.</p>
+  <ul id="plugin-list"></ul>
+  <script>
+    fetch('plugins.json')
+      .then(r => r.json())
+      .then(plugins => {
+        const ul = document.getElementById('plugin-list');
+        plugins.forEach(p => {
+          const li = document.createElement('li');
+          li.innerHTML = `<span class="name">${p.name}</span> - ${p.description} [<a href="${p.url}">repo</a>]`;
+          ul.appendChild(li);
+        });
+      })
+      .catch(err => {
+        document.getElementById('plugin-list').textContent = 'Failed to load plugins: ' + err;
+      });
+  </script>
+</body>
+</html>

--- a/docs/registry/plugins.json
+++ b/docs/registry/plugins.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "agentry-shell",
+    "description": "Execute shell commands as tools",
+    "url": "https://github.com/marcodenic/agentry-shell"
+  },
+  {
+    "name": "agentry-file",
+    "description": "Read and write files on disk",
+    "url": "https://github.com/marcodenic/agentry-file"
+  },
+  {
+    "name": "agentry-web",
+    "description": "Interact with web services via HTTP",
+    "url": "https://github.com/marcodenic/agentry-web"
+  }
+]


### PR DESCRIPTION
## Summary
- create a small Jamstack site in `docs/registry` with plugin info
- automate publishing the registry via GitHub Pages
- link to the registry from the README

## Testing
- `go test ./...` *(fails: not enough arguments in call to core.New)*
- `cd ts-sdk && npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685898098880832085bdbeb221222a7e