### PR TITLE
Add benchmark workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,47 @@
+name: Benchmarks
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Run benchmarks
+        run: |
+          go test ./tests -bench . -run=^$ -benchmem -cpuprofile cpu.out -memprofile mem.out -json > bench.json
+
+      - name: Install pprof
+        run: go install github.com/google/pprof@latest
+
+      - name: Generate flamegraph
+        run: |
+          go tool pprof -svg cpu.out > flame.svg
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-profiles
+          path: |
+            bench.json
+            cpu.out
+            mem.out
+            flame.svg
+
+      - name: Record benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: go
+          output-file-path: bench.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -465,7 +465,7 @@ Agentry aims to become a best-in-class platform for multi-agent AI by anticipati
 | 8.1 | Stress plan → Go tests | Regression       | `pkg/e2e` suite                |  1.3 |
 | 8.2 | GitHub Actions matrix  | Multi‑os         | linux/mac/win jobs             |  8.1 |
 | 8.3 | Chaos monkey job       | Crash resilience | Kill worker mid task           |  4.4 |
-| 8.4 | Benchmarks             | Perf trend       | `go test -bench` + flamegraphs |  7.2 |
+| 8.4 | ~~Benchmarks~~             | Perf trend       | `go test -bench` + flamegraphs |  7.2 |
 
 ## ❾ Developer Experience (dx)
 

--- a/tests/agent_checkpoint_test.go
+++ b/tests/agent_checkpoint_test.go
@@ -21,14 +21,14 @@ func TestAgentCheckpointResume(t *testing.T) {
 	defer store.Close()
 
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: recordClient{}}}
-	ag := core.New(route, nil, memory.NewInMemory(), store, nil)
+    ag := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag.ID = uuid.New()
 
 	if _, err := ag.Run(context.Background(), "hi"); err != nil {
 		t.Fatal(err)
 	}
 
-	ag2 := core.New(route, nil, memory.NewInMemory(), store, nil)
+    ag2 := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag2.ID = ag.ID
 	if err := ag2.Resume(context.Background()); err != nil {
 		t.Fatal(err)

--- a/tests/agent_yield_test.go
+++ b/tests/agent_yield_test.go
@@ -27,7 +27,7 @@ func (c *captureWriter) Write(_ context.Context, e trace.Event) { c.events = app
 func TestAgentRunYields(t *testing.T) {
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: loopMock{}}}
 	cw := &captureWriter{}
-	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, cw)
+    ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), cw)
 
 	out, err := ag.Run(context.Background(), "start")
 	if err != nil {

--- a/tests/bench_test.go
+++ b/tests/bench_test.go
@@ -1,0 +1,21 @@
+package tests
+
+import (
+    "testing"
+
+    "github.com/marcodenic/agentry/internal/router"
+    "github.com/marcodenic/agentry/internal/model"
+)
+
+func BenchmarkRulesSelect(b *testing.B) {
+    rules := router.Rules{
+        {IfContains: []string{"hello", "world"}, Client: model.NewMock()},
+        {IfContains: []string{"foo"}, Client: model.NewMock()},
+        {IfContains: []string{"bar"}, Client: model.NewMock()},
+    }
+    prompt := "say hello world"
+    b.ReportAllocs()
+    for i := 0; i < b.N; i++ {
+        rules.Select(prompt)
+    }
+}


### PR DESCRIPTION
## Summary
- add a simple benchmark exercising the router rules
- track benchmarks in a dedicated GitHub Action that also saves flamegraphs
- update existing tests for new `core.New` signature
- mark benchmark task as complete in ROADMAP

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68589875a0048320a777ffd9e29a4ce5