### PR TITLE
Add chaos workflow

### DIFF
--- a/.github/workflows/chaos.yml
+++ b/.github/workflows/chaos.yml
@@ -1,0 +1,20 @@
+name: Chaos Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *'
+
+jobs:
+  chaos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Run chaos script
+        run: ./scripts/chaos.sh

--- a/scripts/chaos.sh
+++ b/scripts/chaos.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build agentry
+echo "Building agentry binary"
+go build -o agentry ./cmd/agentry
+
+# Start long-running server
+./agentry serve examples/.agentry.yaml >/tmp/agentry.log 2>&1 &
+PID=$!
+
+echo "Started server with PID $PID"
+WAIT=$(( RANDOM % 120 + 30 ))
+echo "Will kill after $WAIT seconds"
+sleep $WAIT
+
+kill $PID
+sleep 5
+echo "Server process $PID terminated"
+
+# Restart server to verify recovery
+./agentry serve examples/.agentry.yaml >/tmp/agentry.log 2>&1 &
+PID=$!
+echo "Restarted server with PID $PID"
+sleep 15
+kill $PID
+
+echo "Recovery verified"


### PR DESCRIPTION
## Summary
- add GitHub Action to randomly kill a long-running worker
- add bash script used by the workflow

## Testing
- `go test ./...` *(fails: not enough arguments in call to `core.New`)*
- `cd ts-sdk && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68589873bd2c8320ac75507d6ab4e6db