### PR TITLE
Improve CI platform coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,15 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 
       - name: Ensure LICENSE exists
+        shell: bash
         run: test -f LICENSE
 
       - name: Set up Go
@@ -21,11 +25,13 @@ jobs:
           go-version: "1.23"
 
       - name: Install and run golangci-lint
+        shell: bash
         run: |
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
           $(go env GOPATH)/bin/golangci-lint run
 
       - name: Run Go tests
+        shell: bash
         run: go test ./...
 
       - name: Set up Node.js
@@ -35,9 +41,11 @@ jobs:
 
       - name: Install and test TS SDK
         working-directory: ts-sdk
+        shell: bash
         run: |
           npm ci
           npm test
 
       - name: Run agentry eval
+        shell: bash
         run: go run ./cmd/agentry eval examples/.agentry.yaml

--- a/tests/agent_checkpoint_test.go
+++ b/tests/agent_checkpoint_test.go
@@ -21,14 +21,14 @@ func TestAgentCheckpointResume(t *testing.T) {
 	defer store.Close()
 
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: recordClient{}}}
-	ag := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag.ID = uuid.New()
 
 	if _, err := ag.Run(context.Background(), "hi"); err != nil {
 		t.Fatal(err)
 	}
 
-	ag2 := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag2 := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag2.ID = ag.ID
 	if err := ag2.Resume(context.Background()); err != nil {
 		t.Fatal(err)

--- a/tests/agent_yield_test.go
+++ b/tests/agent_yield_test.go
@@ -27,7 +27,7 @@ func (c *captureWriter) Write(_ context.Context, e trace.Event) { c.events = app
 func TestAgentRunYields(t *testing.T) {
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: loopMock{}}}
 	cw := &captureWriter{}
-	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, cw)
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), cw)
 
 	out, err := ag.Run(context.Background(), "start")
 	if err != nil {

--- a/tests/plugin_install_test.go
+++ b/tests/plugin_install_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
+	"runtime"
 	"testing"
 
 	"github.com/marcodenic/agentry/internal/plugin"
@@ -18,6 +19,9 @@ func TestInstallPluginUpdatesManifest(t *testing.T) {
 	var cmds [][]string
 	plugin.ExecCommand = func(name string, args ...string) *exec.Cmd {
 		cmds = append(cmds, append([]string{name}, args...))
+		if runtime.GOOS == "windows" {
+			return exec.Command("cmd", "/C", "exit", "0")
+		}
 		return exec.Command("true")
 	}
 	defer func() { plugin.ExecCommand = exec.Command }()


### PR DESCRIPTION
## Summary
- run CI on linux, macOS and windows runners
- make plugin install test succeed on windows
- update agent tests for latest `core.New` signature

## Testing
- `go test ./...`
- `npm install && npm test` in `ts-sdk`

------
https://chatgpt.com/codex/tasks/task_e_685898727cd88320a61dcc0cc4b9cd15