### PR TITLE
Add e2e tests and conditional CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,27 @@ jobs:
 
       - name: Run agentry eval
         run: go run ./cmd/agentry eval examples/.agentry.yaml
+
+  e2e:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check changed paths
+        id: changed
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            core/**
+            engine/**
+
+      - name: Set up Go
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Run e2e tests
+        if: steps.changed.outputs.any_changed == 'true'
+        run: go test ./pkg/e2e/...

--- a/pkg/e2e/checkpoint_resume_test.go
+++ b/pkg/e2e/checkpoint_resume_test.go
@@ -1,0 +1,70 @@
+package e2e
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/model"
+	"github.com/marcodenic/agentry/internal/router"
+	"github.com/marcodenic/agentry/pkg/memstore"
+)
+
+// recordClient returns constant output to simulate a model backend.
+type recordClient struct{}
+
+func (recordClient) Complete(ctx context.Context, msgs []model.ChatMessage, tools []model.ToolSpec) (model.Completion, error) {
+	return model.Completion{Content: "hello"}, nil
+}
+
+// TestCheckpointResumeE2E verifies that an agent can be resumed from a checkpoint
+// and continue processing with its previous state intact.
+func TestCheckpointResumeE2E(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "mem.db")
+	store, err := memstore.NewSQLite(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: recordClient{}}}
+	ag := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
+
+	// Run once and create a checkpoint.
+	if _, err := ag.Run(context.Background(), "hi"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Restore from checkpoint using a new agent instance.
+	ag2 := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
+	ag2.ID = ag.ID
+	if err := ag2.Resume(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	hist := ag2.Mem.History()
+	if len(hist) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(hist))
+	}
+	if hist[0].Output != "hello" {
+		t.Fatalf("unexpected output %s", hist[0].Output)
+	}
+
+	// Continue running to ensure state persists across resumes.
+	if _, err := ag2.Run(context.Background(), "there"); err != nil {
+		t.Fatal(err)
+	}
+
+	ag3 := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
+	ag3.ID = ag.ID
+	if err := ag3.Resume(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	hist = ag3.Mem.History()
+	if len(hist) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(hist))
+	}
+}

--- a/pkg/e2e/sandboxed_tools_test.go
+++ b/pkg/e2e/sandboxed_tools_test.go
@@ -1,0 +1,69 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"reflect"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/config"
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/model"
+	"github.com/marcodenic/agentry/internal/router"
+	"github.com/marcodenic/agentry/internal/tool"
+	"github.com/marcodenic/agentry/pkg/sbox"
+)
+
+type cycleClient struct{ count int }
+
+func (c *cycleClient) Complete(ctx context.Context, msgs []model.ChatMessage, tools []model.ToolSpec) (model.Completion, error) {
+	c.count++
+	if c.count == 1 {
+		args, _ := json.Marshal(map[string]any{})
+		return model.Completion{ToolCalls: []model.ToolCall{{ID: "1", Name: "local", Arguments: args}}}, nil
+	}
+	return model.Completion{Content: "done"}, nil
+}
+
+// TestSandboxedToolE2E ensures shell command tools run through the sandbox engine.
+func TestSandboxedToolE2E(t *testing.T) {
+	var got []string
+	sbox.RunCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		got = append([]string{name}, args...)
+		return exec.CommandContext(ctx, "echo", "ok")
+	}
+	defer func() {
+		sbox.RunCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, name, args...)
+		}
+	}()
+
+	manifest := config.ToolManifest{
+		Name:    "local",
+		Command: "echo hi",
+		Net:     "host",
+	}
+	tl, err := tool.FromManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reg := tool.Registry{"local": tl}
+	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: &cycleClient{}}}
+	ag := core.New(route, reg, memory.NewInMemory(), nil, memory.NewInMemoryVector(), nil)
+
+	out, err := ag.Run(context.Background(), "start")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "done" {
+		t.Fatalf("unexpected output: %s", out)
+	}
+
+	want := []string{"docker", "run", "--rm", "-v", "/workspace:/workspace", "--network", "host", "alpine", "sh", "-c", "echo hi"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args mismatch: got %v want %v", got, want)
+	}
+}

--- a/tests/agent_checkpoint_test.go
+++ b/tests/agent_checkpoint_test.go
@@ -21,14 +21,14 @@ func TestAgentCheckpointResume(t *testing.T) {
 	defer store.Close()
 
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: recordClient{}}}
-	ag := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag.ID = uuid.New()
 
 	if _, err := ag.Run(context.Background(), "hi"); err != nil {
 		t.Fatal(err)
 	}
 
-	ag2 := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag2 := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag2.ID = ag.ID
 	if err := ag2.Resume(context.Background()); err != nil {
 		t.Fatal(err)

--- a/tests/agent_yield_test.go
+++ b/tests/agent_yield_test.go
@@ -27,7 +27,7 @@ func (c *captureWriter) Write(_ context.Context, e trace.Event) { c.events = app
 func TestAgentRunYields(t *testing.T) {
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: loopMock{}}}
 	cw := &captureWriter{}
-	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, cw)
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), cw)
 
 	out, err := ag.Run(context.Background(), "start")
 	if err != nil {


### PR DESCRIPTION
## Summary
- add pkg/e2e tests for checkpoint/resume and sandboxed tools
- update existing tests to use current `core.New` signature
- run e2e tests in CI when files under `core/` or `engine/` change

## Testing
- `go test ./...`
- `go test ./tests/...`
- `npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858986d17dc8320a6c9b605eff9f5c3