### PR TITLE
Add observability dashboard

### DIFF
--- a/README-cloud.md
+++ b/README-cloud.md
@@ -51,3 +51,19 @@ npm run build
 ```
 
 The build output in `ui/web/dist` is embedded into the hub and served at `/` when running `agentry serve --metrics`.
+
+## Using the Dashboard
+
+Start the server with metrics enabled and then open `http://localhost:8080` in a browser:
+
+```bash
+agentry serve --config examples/.agentry.yaml --metrics
+```
+
+The dashboard shows:
+
+- **Running Agents** – list of available agent IDs from `/agents`.
+- **Traces** – live SSE events plus OTLP spans fetched from `/traces`.
+- **Metrics Graphs** – Prometheus counters visualised in real time from `/metrics`.
+
+Data refreshes every few seconds to provide a near real‑time view of the system.

--- a/internal/trace/memory.go
+++ b/internal/trace/memory.go
@@ -1,0 +1,28 @@
+package trace
+
+import "context"
+
+// MemoryWriter stores events in memory for debugging.
+type MemoryWriter struct {
+	Events []Event
+	Limit  int
+}
+
+func NewMemory(limit int) *MemoryWriter {
+	return &MemoryWriter{Limit: limit}
+}
+
+func (m *MemoryWriter) Write(_ context.Context, e Event) {
+	if m.Limit > 0 && len(m.Events) >= m.Limit {
+		copy(m.Events, m.Events[1:])
+		m.Events[len(m.Events)-1] = e
+	} else {
+		m.Events = append(m.Events, e)
+	}
+}
+
+func (m *MemoryWriter) All() []Event {
+	out := make([]Event, len(m.Events))
+	copy(out, m.Events)
+	return out
+}

--- a/internal/trace/multi.go
+++ b/internal/trace/multi.go
@@ -1,0 +1,14 @@
+package trace
+
+import "context"
+
+// MultiWriter dispatches events to multiple writers.
+type MultiWriter struct{ writers []Writer }
+
+func NewMulti(w ...Writer) *MultiWriter { return &MultiWriter{writers: w} }
+
+func (m *MultiWriter) Write(ctx context.Context, e Event) {
+	for _, w := range m.writers {
+		w.Write(ctx, e)
+	}
+}

--- a/tests/agent_checkpoint_test.go
+++ b/tests/agent_checkpoint_test.go
@@ -21,14 +21,14 @@ func TestAgentCheckpointResume(t *testing.T) {
 	defer store.Close()
 
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: recordClient{}}}
-	ag := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag.ID = uuid.New()
 
 	if _, err := ag.Run(context.Background(), "hi"); err != nil {
 		t.Fatal(err)
 	}
 
-	ag2 := core.New(route, nil, memory.NewInMemory(), store, nil)
+	ag2 := core.New(route, nil, memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	ag2.ID = ag.ID
 	if err := ag2.Resume(context.Background()); err != nil {
 		t.Fatal(err)

--- a/tests/agent_yield_test.go
+++ b/tests/agent_yield_test.go
@@ -27,7 +27,7 @@ func (c *captureWriter) Write(_ context.Context, e trace.Event) { c.events = app
 func TestAgentRunYields(t *testing.T) {
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: loopMock{}}}
 	cw := &captureWriter{}
-	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, cw)
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), cw)
 
 	out, err := ag.Run(context.Background(), "start")
 	if err != nil {

--- a/ui/web/package.json
+++ b/ui/web/package.json
@@ -10,6 +10,7 @@
     "@sveltejs/adapter-static": "^2.0.3",
     "@sveltejs/kit": "^2.5.1",
     "svelte": "^4.2.9",
-    "vite": "^4.4.0"
+    "vite": "^4.4.0",
+    "chart.js": "^4.4.1"
   }
 }


### PR DESCRIPTION
## Summary
- enhance SvelteKit dashboard to show agents, traces and metrics graphs
- expose `/agents` and `/traces` endpoints in Go server
- track recent trace events in memory
- document dashboard usage in cloud README
- update tests for new Agent constructor signature

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`
- `npm install --legacy-peer-deps` and `npm run build` in `ui/web` *(fails: SyntaxError: The requested module '@sveltejs/kit/vite' does not provide an export named 'vitePreprocess')*

------
https://chatgpt.com/codex/tasks/task_e_6858983bced08320bbb3e49bbde9c0ac