### PR TITLE
Add Kubernetes manifests and Helm chart

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,19 @@
+# Deploying Agentry
+
+This directory contains Kubernetes manifests and a Helm chart for deploying Agentry workers.
+
+The manifests under `k8s/` are raw YAML files that can be applied directly:
+
+```bash
+kubectl apply -f k8s/
+```
+
+The `helm/agentry` chart provides the same resources with configurable values for
+queue address, autoscaling and storage:
+
+```bash
+helm install agentry helm/agentry
+```
+
+Adjust values by creating a YAML file and passing it with `-f`. See
+`helm/agentry/values.yaml` for all available options.

--- a/deploy/helm/agentry/Chart.yaml
+++ b/deploy/helm/agentry/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: agentry
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/helm/agentry/templates/_helpers.tpl
+++ b/deploy/helm/agentry/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "agentry.name" -}}
+agentry
+{{- end -}}
+
+{{- define "agentry.fullname" -}}
+{{ include "agentry.name" . }}
+{{- end -}}

--- a/deploy/helm/agentry/templates/deployment.yaml
+++ b/deploy/helm/agentry/templates/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agentry.fullname" . }}
+  labels:
+    app: {{ include "agentry.name" . }}
+spec:
+  replicas: {{ .Values.autoscaling.minReplicas }}
+  selector:
+    matchLabels:
+      app: {{ include "agentry.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "agentry.name" . }}
+    spec:
+      containers:
+      - name: agentry
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: NATS_URL
+          value: {{ .Values.queue.address | quote }}
+        volumeMounts:
+        - name: data
+          mountPath: /data
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: {{ include "agentry.fullname" . }}-data

--- a/deploy/helm/agentry/templates/hpa.yaml
+++ b/deploy/helm/agentry/templates/hpa.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "agentry.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "agentry.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/agentry/templates/pvc.yaml
+++ b/deploy/helm/agentry/templates/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "agentry.fullname" . }}-data
+spec:
+  accessModes:
+  - {{ .Values.storage.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.size }}

--- a/deploy/helm/agentry/templates/service.yaml
+++ b/deploy/helm/agentry/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agentry.fullname" . }}
+  labels:
+    app: {{ include "agentry.name" . }}
+spec:
+  selector:
+    app: {{ include "agentry.name" . }}
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080

--- a/deploy/helm/agentry/values.yaml
+++ b/deploy/helm/agentry/values.yaml
@@ -1,0 +1,17 @@
+image:
+  repository: agentry
+  tag: latest
+  pullPolicy: IfNotPresent
+
+queue:
+  address: nats://nats:4222
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+
+storage:
+  size: 1Gi
+  accessMode: ReadWriteOnce

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentry-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agentry-worker
+  template:
+    metadata:
+      labels:
+        app: agentry-worker
+    spec:
+      containers:
+      - name: worker
+        image: agentry:latest
+        env:
+        - name: NATS_URL
+          value: nats://nats:4222
+        volumeMounts:
+        - name: data
+          mountPath: /data
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: agentry-data

--- a/deploy/k8s/hpa.yaml
+++ b/deploy/k8s/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: agentry-worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: agentry-worker
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80

--- a/deploy/k8s/pvc.yaml
+++ b/deploy/k8s/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: agentry-data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentry-worker
+spec:
+  selector:
+    app: agentry-worker
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080


### PR DESCRIPTION
## Summary
- create example Kubernetes manifests in `deploy/k8s`
- add Helm chart under `deploy/helm/agentry`
- document deployment instructions in `deploy/README.md`

## Testing
- `go test ./...` *(fails: missing go.sum entries)*
- `cd ts-sdk && npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858ab8f66048320a50d9c58e431672a