### PR TITLE
Add packaging scripts and install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,33 @@ For the upcoming cloud deployment model, see [README-cloud.md](./README-cloud.md
 
 ---
 
+## 📦 Installation
+
+Prebuilt binaries are available on [GitHub Releases](https://github.com/marcodenic/agentry/releases).
+
+### Homebrew (macOS/Linux)
+
+```bash
+brew tap marcodenic/agentry
+brew install agentry
+```
+
+### Scoop (Windows)
+
+```powershell
+scoop bucket add agentry https://github.com/marcodenic/agentry
+scoop install agentry
+```
+
+### Debian
+
+```bash
+wget https://github.com/marcodenic/agentry/releases/download/vX.Y.Z/agentry_X.Y.Z_amd64.deb
+sudo dpkg -i agentry_X.Y.Z_amd64.deb
+```
+
+---
+
 ## 🚀 Quick Start
 
 ```bash

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="$1"
+ARCH="amd64"
+BUILD_DIR="dist/deb"
+INSTALL_DIR="$BUILD_DIR/usr/local/bin"
+
+mkdir -p "$INSTALL_DIR" "$BUILD_DIR/DEBIAN"
+cp "dist/agentry-linux-$ARCH" "$INSTALL_DIR/agentry"
+chmod 755 "$INSTALL_DIR/agentry"
+
+cat > "$BUILD_DIR/DEBIAN/control" <<EOF2
+Package: agentry
+Version: $VERSION
+Section: utils
+Priority: optional
+Architecture: $ARCH
+Maintainer: Agentry Team <dev@none>
+Description: Minimal, performant AI-Agent runtime
+EOF2
+
+dpkg-deb --build "$BUILD_DIR" "dist/agentry_${VERSION}_${ARCH}.deb"
+printf "Debian package created at dist/agentry_${VERSION}_${ARCH}.deb\n"

--- a/scripts/package-homebrew.sh
+++ b/scripts/package-homebrew.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="$1"
+DARWIN_BINARY="dist/agentry-darwin-amd64"
+LINUX_BINARY="dist/agentry-linux-amd64"
+
+DARWIN_SHA=$(shasum -a 256 "$DARWIN_BINARY" | awk '{print $1}')
+LINUX_SHA=$(shasum -a 256 "$LINUX_BINARY" | awk '{print $1}')
+
+FORMULA_DIR="dist/homebrew"
+mkdir -p "$FORMULA_DIR"
+FORMULA="$FORMULA_DIR/agentry.rb"
+
+cat > "$FORMULA" <<EOF2
+class Agentry < Formula
+  desc "Minimal, performant AI-Agent runtime"
+  homepage "https://github.com/marcodenic/agentry"
+  version "$VERSION"
+
+  on_macos do
+    url "https://github.com/marcodenic/agentry/releases/download/v#{version}/agentry-darwin-amd64"
+    sha256 "$DARWIN_SHA"
+  end
+
+  on_linux do
+    url "https://github.com/marcodenic/agentry/releases/download/v#{version}/agentry-linux-amd64"
+    sha256 "$LINUX_SHA"
+  end
+
+  def install
+    bin.install "agentry"
+  end
+end
+EOF2
+
+printf "Homebrew formula written to %s\n" "$FORMULA"

--- a/scripts/package-scoop.ps1
+++ b/scripts/package-scoop.ps1
@@ -1,0 +1,21 @@
+param(
+  [string]$Version
+)
+
+$binary = "dist/agentry-windows-amd64.exe"
+$sha = (Get-FileHash $binary -Algorithm SHA256).Hash
+$manifestDir = "dist/scoop"
+New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+$manifestPath = Join-Path $manifestDir "agentry.json"
+
+@{
+    version = $Version
+    architecture = @{ 
+        "64bit" = @{ url = "https://github.com/marcodenic/agentry/releases/download/v$Version/agentry-windows-amd64.exe"; hash = $sha }
+    }
+    bin = "agentry-windows-amd64.exe"
+    description = "Minimal, performant AI-Agent runtime"
+    homepage = "https://github.com/marcodenic/agentry"
+} | ConvertTo-Json -Depth 3 | Out-File -Encoding ASCII $manifestPath
+
+Write-Output "Scoop manifest written to $manifestPath"


### PR DESCRIPTION
## Summary
- add scripts for packaging Homebrew, Scoop, and Debian
- document package-based installation

## Testing
- `go test ./...` *(fails: missing go.sum entries)*
- `cd ts-sdk && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858ab8c47088320b9f655881deda5f7