### PR TITLE
Add VS Code SSE extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,18 @@ agentry dev
 ```
 
 ---
+## 🧩 VS Code Extension
+
+The `extensions/vscode-agentry` folder contains a small helper extension that streams output from a running server.
+
+```bash
+cd extensions/vscode-agentry
+npm install
+npm run build
+```
+
+Start the Agentry server with `agentry serve --config examples/.agentry.yaml` then run **Agentry: Open Panel** from VS Code to connect. Use **Agentry: Stop Stream** to end the session.
+
 
 ## 🔌 Plugin Registry
 

--- a/docs/vscode-extension.md
+++ b/docs/vscode-extension.md
@@ -1,0 +1,24 @@
+# VS Code Extension
+
+This extension streams agent output from a running Agentry server using the VS Code extension API and Server-Sent Events (SSE).
+
+## Setup
+
+```bash
+cd extensions/vscode-agentry
+npm install
+npm run build
+```
+
+Use the VS Code Extensions view to load this folder as an extension ("Run Extension" from the debug tab or `code --extensionDevelopmentPath=...`).
+
+## Connecting
+
+1. Launch an Agentry server:
+   ```bash
+   agentry serve --config examples/.agentry.yaml
+   ```
+2. In VS Code, execute the **Agentry: Open Panel** command.
+3. Enter the server URL (`http://localhost:8080` by default) and a message.
+4. Watch the streaming tokens appear in the **Agentry SSE** output channel.
+5. Run **Agentry: Stop Stream** to disconnect.

--- a/extensions/vscode-agentry/README.md
+++ b/extensions/vscode-agentry/README.md
@@ -1,0 +1,22 @@
+# Agentry VS Code Extension
+
+This extension streams agent output from a running Agentry server using Server‑Sent Events (SSE).
+
+## Building
+
+```bash
+cd extensions/vscode-agentry
+npm install
+npm run build
+```
+
+## Usage
+
+1. Start the Agentry server in a terminal:
+   ```bash
+   agentry serve --config examples/.agentry.yaml
+   ```
+2. In VS Code, run the **Agentry: Open Panel** command.
+3. Enter the server URL (defaults to `http://localhost:8080`) and a message to send.
+4. Streaming output appears in the **Agentry SSE** output channel.
+5. Run **Agentry: Stop Stream** to close the connection.

--- a/extensions/vscode-agentry/package.json
+++ b/extensions/vscode-agentry/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "agentry-vscode",
+  "displayName": "Agentry",
+  "description": "SSE output panel for Agentry server",
+  "version": "0.0.1",
+  "publisher": "agentry",
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "activationEvents": [
+    "onCommand:agentry.openPanel",
+    "onCommand:agentry.stopStream"
+  ],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "commands": [
+      { "command": "agentry.openPanel", "title": "Agentry: Open Panel" },
+      { "command": "agentry.stopStream", "title": "Agentry: Stop Stream" }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run build",
+    "build": "tsc -p ./",
+    "compile": "tsc -watch -p ./",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "cross-fetch": "^4.0.0",
+    "eventsource-parser": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "typescript": "^5.5.0",
+    "vscode": "^1.1.38"
+  }
+}

--- a/extensions/vscode-agentry/src/extension.ts
+++ b/extensions/vscode-agentry/src/extension.ts
@@ -1,0 +1,73 @@
+import * as vscode from 'vscode';
+import fetch from 'cross-fetch';
+import { createParser } from 'eventsource-parser';
+
+let controller: AbortController | undefined;
+let channel: vscode.OutputChannel;
+
+export function activate(context: vscode.ExtensionContext) {
+  channel = vscode.window.createOutputChannel('Agentry SSE');
+  context.subscriptions.push(channel);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('agentry.openPanel', async () => {
+      const serverUrl = await vscode.window.showInputBox({
+        prompt: 'Agentry server URL',
+        value: 'http://localhost:8080',
+      });
+      if (!serverUrl) {
+        return;
+      }
+      const input = await vscode.window.showInputBox({
+        prompt: 'Message to send',
+        value: 'hello',
+      });
+      if (input === undefined) {
+        return;
+      }
+      startStream(serverUrl, input);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('agentry.stopStream', () => {
+      controller?.abort();
+      controller = undefined;
+      channel.appendLine('\n--- stream stopped ---\n');
+    })
+  );
+}
+
+async function startStream(serverUrl: string, input: string) {
+  controller?.abort();
+  controller = new AbortController();
+  channel.show(true);
+  channel.clear();
+  channel.appendLine(`Connecting to ${serverUrl}...`);
+  let res: any;
+  try {
+    res = await fetch(`${serverUrl}/invoke`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ input, stream: true }),
+      signal: controller.signal,
+    });
+  } catch (err: any) {
+    vscode.window.showErrorMessage(`Failed to connect: ${err.message}`);
+    return;
+  }
+
+  const parser = createParser((event) => {
+    if (event.type === 'event') {
+      channel.append(event.data);
+    }
+  });
+
+  for await (const chunk of res.body as any as AsyncIterable<Uint8Array>) {
+    parser.feed(new TextDecoder().decode(chunk));
+  }
+}
+
+export function deactivate() {
+  controller?.abort();
+}

--- a/extensions/vscode-agentry/tsconfig.json
+++ b/extensions/vscode-agentry/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "lib": ["ES2019"],
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add a new VS Code extension that streams server output via SSE
- document how to use the extension
- mention the extension in the main README

## Testing
- `go test ./...` *(fails: missing modules due to blocked downloads)*
- `cd ts-sdk && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858ab90070883208702f4e353829e24