### PR TITLE
Add local cluster compose and docs

### DIFF
--- a/README-cloud.md
+++ b/README-cloud.md
@@ -108,3 +108,24 @@ Persist the agent's state and remove it from memory.
   "agent_id": "<uuid>"
 }
 ```
+
+## Local Cluster Setup
+
+A `docker-compose.yml` is provided for running a small cluster locally. It starts
+NATS, an agent hub, two agent nodes, and a worker process. Run it from the
+repository root:
+
+```bash
+docker compose up
+```
+
+Services are exposed on the following ports:
+
+- **NATS** – `4222`
+- **Hub** – `9090`
+- **Node 1** – `9091`
+- **Node 2** – `9092`
+
+The hub automatically connects to both nodes. The worker subscribes to the NATS
+queue for task execution. Use `grpcurl` or your own client to call the
+`AgentHub` API on `localhost:9090`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -472,7 +472,7 @@ Agentry aims to become a best-in-class platform for multi-agent AI by anticipati
 | ID  |  ‑ [ ] Task                 | Why                | How                 | Deps |
 | --- | --------------------------- | ------------------ | ------------------- | ---- |
 | 9.1 | One‑line installer          | Fast start         | Homebrew/scoop/deb  | —    |
-| 9.2 | Docker‑compose mini‑cluster | Showcase           | `docker compose up` |  4.4 |
+| 9.2 | ~~Docker‑compose mini‑cluster~~ | Showcase           | `docker compose up` |  4.4 |
 | 9.3 | Helm chart                  | Enterprise         | k8s templates       |  4.4 |
 | 9.4 | VS Code extension           | Editor integration | SSE panel           |  7.1 |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3.8'
+services:
+  nats:
+    image: nats:2
+    ports:
+      - "4222:4222"
+
+  hub:
+    image: golang:1.23
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: go run ./cmd/agent-hub -addr :9090 -nodes node1:9091,node2:9092
+    depends_on:
+      - node1
+      - node2
+    ports:
+      - "9090:9090"
+
+  node1:
+    image: golang:1.23
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: go run ./cmd/agent-node -addr :9091
+    depends_on:
+      - nats
+    ports:
+      - "9091:9091"
+
+  node2:
+    image: golang:1.23
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: go run ./cmd/agent-node -addr :9092
+    depends_on:
+      - nats
+    ports:
+      - "9092:9092"
+
+  worker:
+    image: golang:1.23
+    working_dir: /app
+    volumes:
+      - .:/app
+    environment:
+      - NATS_URL=nats://nats:4222
+    command: go run ./cmd/worker
+    depends_on:
+      - nats
+


### PR DESCRIPTION
## Summary
- add docker-compose.yml with hub, workers and NATS
- document running the local cluster in README-cloud
- mark docker-compose mini-cluster complete in roadmap

## Testing
- `go test ./...` *(fails: missing go.sum entries and module downloads blocked)*
- `cd ts-sdk && npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858ab8def0c8320b59d59aa41208276