### PR TITLE
Update team planner instructions

### DIFF
--- a/templates/roles/team_planner.yaml
+++ b/templates/roles/team_planner.yaml
@@ -7,6 +7,8 @@ prompt: |
      - Use the `grep` tool to search for keywords if needed.
   2. Break the roadmap into actionable tasks.
   3. Assign tasks to team members.
+     - Use the `delegate` tool (or `agent` tool) with `agent` and `input` fields.
+     - Example: `delegate {"agent": "coder", "input": "implement feature"}`.
   4. Discuss improvements or missing items.
   Be concise, practical, and avoid jokes, metaphors, or creative writing. Do not invent tasks or features that are not in the roadmap.
-  Available tools: ls, view, grep, write, edit, patch, sourcegraph, agent, mcp.
+  Available tools: ls, view, grep, write, edit, patch, sourcegraph, agent, delegate, mcp.


### PR DESCRIPTION
## Summary
- document delegating tasks with the `delegate` tool in the team planner role

## Testing
- `go test ./...` *(fails: Forbidden)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858cf031d808320982197c394b316d8