### PR TITLE
Update docs for delegation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ tools:
     type: builtin
   - name: agent # 🤖 launch a search agent
     type: builtin
+  - name: delegate # 📋 assign tasks to another agent
+    type: builtin
   - name: mcp # 🎮 connect to MCP servers
     type: builtin
 ```
@@ -169,6 +171,16 @@ The example configuration already lists these tools so they appear in the TUI's 
 Use the `mcp` tool to connect to Multi-User Connection Protocol servers. Set its
 address in your YAML config and the agent can send MCP commands and read the
 responses.
+
+### 📋 Delegating Tasks
+
+Planners can forward work to specialised agents using the new `delegate` tool.
+Include it in your `.agentry.yaml` and call it with the target agent name and
+task description:
+
+```bash
+delegate --agent coder --task "write unit tests"
+```
 
 ### OpenAPI & MCP Specs
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ Agentry is a minimal, extensible agent runtime written in Go with a TypeScript S
 | **Evaluation**    | YAML test suites, CLI `agentry eval`                     |
 | **SDK**           | JS/TS client (`@marcodenic/agentry`), supports streaming |
 | **Registry**      | [Plugin Registry](registry/)                             |
+| **Delegation**    | `delegate` tool lets planners assign tasks to agents      |
 
 For the upcoming cloud deployment model, see [README-cloud.md](../README-cloud.md).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,3 +47,20 @@ Create a `theme.json` file to customise colours and keyboard shortcuts. Agentry 
   }
 }
 ```
+
+## Delegating Tasks
+
+Planners can offload work to another agent using the `delegate` tool. Add it to
+your configuration:
+
+```yaml
+tools:
+  - name: delegate
+    type: builtin
+```
+
+Invoke the tool with the target agent and task:
+
+```bash
+delegate --agent coder --task "draft documentation"
+```


### PR DESCRIPTION
## Summary
- document new `delegate` tool in feature table
- add delegation command usage in main README and docs

## Testing
- `go test ./...` *(fails: Forbidden)*
- `cd ts-sdk && npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858cf04827483209f8792907e431166