### PR TITLE
Implement agent delegation tool

### DIFF
--- a/internal/converse/team.go
+++ b/internal/converse/team.go
@@ -9,6 +9,7 @@ import (
 	"github.com/marcodenic/agentry/internal/memory"
 	"github.com/marcodenic/agentry/internal/model"
 	"github.com/marcodenic/agentry/internal/router"
+	"github.com/marcodenic/agentry/internal/team"
 )
 
 // Team manages a multi-agent conversation step by step.
@@ -67,4 +68,17 @@ func (t *Team) Step(ctx context.Context) (int, string, error) {
 	t.msg = out
 	t.turn++
 	return idx, out, nil
+}
+
+// ErrUnknownAgent is returned when Call is invoked with a name that doesn't exist.
+var ErrUnknownAgent = team.ErrUnknownAgent
+
+// Call runs the named agent with the provided input.
+func (t *Team) Call(ctx context.Context, name, input string) (string, error) {
+	for i, n := range t.names {
+		if n == name {
+			return t.agents[i].Run(ctx, input)
+		}
+	}
+	return "", fmt.Errorf("%w: %s", ErrUnknownAgent, name)
 }

--- a/internal/team/context.go
+++ b/internal/team/context.go
@@ -1,0 +1,40 @@
+package team
+
+import (
+	"context"
+	"errors"
+)
+
+// Caller represents a team capable of handling delegated calls.
+type Caller interface {
+	Call(ctx context.Context, agent, input string) (string, error)
+}
+
+// ctxKey is used for storing the current team in a context.
+type ctxKey struct{}
+
+// ErrNoTeam indicates the context is missing a team value.
+var ErrNoTeam = errors.New("no team in context")
+
+// ErrUnknownAgent is returned when the named agent does not exist.
+var ErrUnknownAgent = errors.New("unknown agent")
+
+// WithContext returns a new context carrying t.
+func WithContext(ctx context.Context, t Caller) context.Context {
+	return context.WithValue(ctx, ctxKey{}, t)
+}
+
+// FromContext retrieves the team stored in ctx.
+func FromContext(ctx context.Context) (Caller, bool) {
+	t, ok := ctx.Value(ctxKey{}).(Caller)
+	return t, ok
+}
+
+// Call sends input to the named agent of the team stored in ctx.
+func Call(ctx context.Context, name, input string) (string, error) {
+	t, ok := FromContext(ctx)
+	if !ok || t == nil {
+		return "", ErrNoTeam
+	}
+	return t.Call(ctx, name, input)
+}

--- a/internal/tool/manifest.go
+++ b/internal/tool/manifest.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/marcodenic/agentry/internal/config"
 	"github.com/marcodenic/agentry/internal/patch"
+	"github.com/marcodenic/agentry/internal/team"
 	"github.com/marcodenic/agentry/pkg/sbox"
 )
 
@@ -493,15 +494,19 @@ var builtinMap = map[string]builtinSpec{
 		},
 	},
 	"agent": {
-		Desc: "Launch a search agent",
+		Desc: "Delegate a message to another agent",
 		Schema: map[string]any{
-			"type":       "object",
-			"properties": map[string]any{"query": map[string]any{"type": "string"}},
-			"required":   []string{"query"},
+			"type": "object",
+			"properties": map[string]any{
+				"agent": map[string]any{"type": "string"},
+				"input": map[string]any{"type": "string"},
+			},
+			"required": []string{"agent", "input"},
 		},
 		Exec: func(ctx context.Context, args map[string]any) (string, error) {
-			query, _ := args["query"].(string)
-			return "agent searched: " + query, nil
+			name, _ := args["agent"].(string)
+			input, _ := args["input"].(string)
+			return team.Call(ctx, name, input)
 		},
 	},
 }

--- a/tests/agent_tool_test.go
+++ b/tests/agent_tool_test.go
@@ -1,0 +1,58 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/converse"
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/model"
+	"github.com/marcodenic/agentry/internal/router"
+	"github.com/marcodenic/agentry/internal/team"
+	"github.com/marcodenic/agentry/internal/tool"
+)
+
+// staticClient returns a fixed response.
+type staticClient struct{ out string }
+
+func (s staticClient) Complete(ctx context.Context, msgs []model.ChatMessage, tools []model.ToolSpec) (model.Completion, error) {
+	return model.Completion{Content: s.out}, nil
+}
+
+func newTestTeam(t *testing.T, reply string) *converse.Team {
+	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: staticClient{out: reply}}}
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), nil)
+	tm, err := converse.NewTeam(ag, 2, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tm
+}
+
+func TestAgentToolDelegates(t *testing.T) {
+	tm := newTestTeam(t, "ok")
+	ctx := team.WithContext(context.Background(), tm)
+	tl, ok := tool.DefaultRegistry().Use("agent")
+	if !ok {
+		t.Fatal("agent tool missing")
+	}
+	out, err := tl.Execute(ctx, map[string]any{"agent": "Agent1", "input": "hi"})
+	if err != nil {
+		t.Fatalf("exec failed: %v", err)
+	}
+	if out != "ok" {
+		t.Fatalf("unexpected output %s", out)
+	}
+}
+
+func TestAgentToolUnknown(t *testing.T) {
+	tm := newTestTeam(t, "ignore")
+	ctx := team.WithContext(context.Background(), tm)
+	tl, _ := tool.DefaultRegistry().Use("agent")
+	_, err := tl.Execute(ctx, map[string]any{"agent": "Bogus", "input": "hi"})
+	if !errors.Is(err, team.ErrUnknownAgent) {
+		t.Fatalf("expected unknown agent error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add `team` package for context helpers
- delegate messages between teammates with `converse.Team.Call`
- implement `agent` builtin tool using `team.Call`
- test delegation success and unknown agent error

## Testing
- `go test ./...` *(fails: access to storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6858cefe26b48320ab2ea12fe4e4089d