### PR TITLE
Propagate team via context in tools

### DIFF
--- a/internal/converse/team.go
+++ b/internal/converse/team.go
@@ -9,6 +9,7 @@ import (
 	"github.com/marcodenic/agentry/internal/memory"
 	"github.com/marcodenic/agentry/internal/model"
 	"github.com/marcodenic/agentry/internal/router"
+	"github.com/marcodenic/agentry/internal/teamctx"
 )
 
 // Team manages a multi-agent conversation step by step.
@@ -67,4 +68,14 @@ func (t *Team) Step(ctx context.Context) (int, string, error) {
 	t.msg = out
 	t.turn++
 	return idx, out, nil
+}
+
+// Call returns the result of invoking the agent tool using the team from the context.
+func (t *Team) Call(ctx context.Context, query string) (string, error) {
+	team, ok := ctx.Value(teamctx.Key{}).(*Team)
+	if !ok || team == nil {
+		return "", errors.New("team not found in context")
+	}
+	_ = team // retrieved but currently unused
+	return "agent searched: " + query, nil
 }

--- a/internal/teamctx/key.go
+++ b/internal/teamctx/key.go
@@ -1,0 +1,4 @@
+package teamctx
+
+// Key is the context key used to store a *converse.Team.
+type Key struct{}

--- a/internal/tool/manifest.go
+++ b/internal/tool/manifest.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/marcodenic/agentry/internal/config"
 	"github.com/marcodenic/agentry/internal/patch"
+	"github.com/marcodenic/agentry/internal/teamctx"
 	"github.com/marcodenic/agentry/pkg/sbox"
 )
 
@@ -501,7 +502,13 @@ var builtinMap = map[string]builtinSpec{
 		},
 		Exec: func(ctx context.Context, args map[string]any) (string, error) {
 			query, _ := args["query"].(string)
-			return "agent searched: " + query, nil
+			team, ok := ctx.Value(teamctx.Key{}).(interface {
+				Call(context.Context, string) (string, error)
+			})
+			if !ok {
+				return "", errors.New("team not found in context")
+			}
+			return team.Call(ctx, query)
 		},
 	},
 }

--- a/internal/tui/team.go
+++ b/internal/tui/team.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/marcodenic/agentry/internal/converse"
 	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/teamctx"
 )
 
 type teamMsg struct {
@@ -51,7 +52,8 @@ func (m TeamModel) Init() tea.Cmd {
 
 func (m TeamModel) stepCmd() tea.Cmd {
 	return func() tea.Msg {
-		idx, out, err := m.team.Step(context.Background())
+		ctx := context.WithValue(context.Background(), teamctx.Key{}, m.team)
+		idx, out, err := m.team.Step(ctx)
 		if err != nil {
 			return errMsg{err}
 		}

--- a/tests/agent_tool_context_test.go
+++ b/tests/agent_tool_context_test.go
@@ -1,0 +1,44 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/converse"
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/model"
+	"github.com/marcodenic/agentry/internal/router"
+	"github.com/marcodenic/agentry/internal/teamctx"
+	"github.com/marcodenic/agentry/internal/tool"
+)
+
+// simpleMock returns a completion that triggers the agent tool.
+type agentMock struct{}
+
+func (agentMock) Complete(ctx context.Context, msgs []model.ChatMessage, tools []model.ToolSpec) (model.Completion, error) {
+	args, _ := json.Marshal(map[string]any{"query": "foo"})
+	return model.Completion{ToolCalls: []model.ToolCall{{ID: "1", Name: "agent", Arguments: args}}}, nil
+}
+
+func TestAgentToolContext(t *testing.T) {
+	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: agentMock{}}}
+	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), nil)
+	team, err := converse.NewTeam(ag, 1, "hi")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ctx := context.WithValue(context.Background(), teamctx.Key{}, team)
+	tl, ok := tool.DefaultRegistry()["agent"]
+	if !ok {
+		t.Fatalf("agent tool missing")
+	}
+	out, err := tl.Execute(ctx, map[string]any{"query": "foo"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out == "" {
+		t.Fatalf("expected output, got empty")
+	}
+}


### PR DESCRIPTION
## Summary
- add shared team context key package
- use context value when stepping the team
- retrieve team from context in agent tool and new `Team.Call`
- test that team context is passed to tools

## Testing
- `go test ./...` *(fails: github.com/klauspost/compress download forbidden)*
- `npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858cf00e650832083baa2d157e0ef80