### PR TITLE
Add sub-agent runtime and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ tools:
     type: builtin
   - name: agent # 🤖 launch a search agent
     type: builtin
+    # Runs a sub-agent with the provided `query` and returns its final answer
   - name: mcp # 🎮 connect to MCP servers
     type: builtin
 ```

--- a/examples/.agentry.yaml
+++ b/examples/.agentry.yaml
@@ -52,6 +52,7 @@ tools:
   - name: agent
     type: builtin
     description: Launch a search agent
+    # pass a `query` argument when invoking
   - name: mcp
     type: builtin
     description: Connect to an MCP server

--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -57,7 +57,11 @@ func (a *Agent) Run(ctx context.Context, input string) (string, error) {
 			if err := json.Unmarshal(tc.Arguments, &args); err != nil {
 				return "", err
 			}
-			r, err := t.Execute(ctx, args)
+			fn := func(c context.Context, q string) (string, error) {
+				sub := a.Spawn()
+				return sub.Run(c, q)
+			}
+			r, err := t.Execute(tool.WithSpawn(ctx, fn), args)
 			if err != nil {
 				return "", err
 			}

--- a/internal/tool/context.go
+++ b/internal/tool/context.go
@@ -1,0 +1,20 @@
+package tool
+
+import "context"
+
+// SpawnFn represents a function that runs a query using a new agent derived
+// from the parent.
+type SpawnFn func(context.Context, string) (string, error)
+
+type ctxKey struct{}
+
+// WithSpawn returns a context carrying fn so tools can launch sub-agents.
+func WithSpawn(ctx context.Context, fn SpawnFn) context.Context {
+	return context.WithValue(ctx, ctxKey{}, fn)
+}
+
+// SpawnFromContext retrieves the SpawnFn stored in ctx.
+func SpawnFromContext(ctx context.Context) (SpawnFn, bool) {
+	fn, ok := ctx.Value(ctxKey{}).(SpawnFn)
+	return fn, ok
+}

--- a/internal/tool/manifest.go
+++ b/internal/tool/manifest.go
@@ -471,10 +471,22 @@ var builtinMap = map[string]builtinSpec{
 			"type":       "object",
 			"properties": map[string]any{"query": map[string]any{"type": "string"}},
 			"required":   []string{"query"},
+			"example":    map[string]any{"query": "hello"},
 		},
 		Exec: func(ctx context.Context, args map[string]any) (string, error) {
 			query, _ := args["query"].(string)
-			return "agent searched: " + query, nil
+			if query == "" {
+				return "", errors.New("missing query")
+			}
+			fn, ok := SpawnFromContext(ctx)
+			if !ok {
+				return "", errors.New("missing spawn function")
+			}
+			out, err := fn(ctx, query)
+			if err != nil {
+				return "", err
+			}
+			return out, nil
 		},
 	},
 }

--- a/tests/agent_builtin_test.go
+++ b/tests/agent_builtin_test.go
@@ -1,0 +1,31 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/model"
+	"github.com/marcodenic/agentry/internal/router"
+	"github.com/marcodenic/agentry/internal/tool"
+)
+
+func TestAgentBuiltin(t *testing.T) {
+	reg := tool.DefaultRegistry()
+	route := router.Rules{{IfContains: []string{""}, Client: model.NewMock()}}
+	parent := core.New(route, reg, memory.NewInMemory(), nil)
+
+	agentTool, _ := reg.Use("agent")
+	spawn := func(ctx context.Context, q string) (string, error) {
+		sub := parent.Spawn()
+		return sub.Run(ctx, q)
+	}
+	out, err := agentTool.Execute(tool.WithSpawn(context.Background(), spawn), map[string]any{"query": "hi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "hello" {
+		t.Fatalf("expected hello, got %s", out)
+	}
+}

--- a/tests/builtin_cross_test.go
+++ b/tests/builtin_cross_test.go
@@ -30,8 +30,8 @@ func TestBuiltinsCrossPlatform(t *testing.T) {
 			}
 		}
 		t.Run(name, func(t *testing.T) {
-			if name == "patch" || name == "ping" || name == "fetch" || name == "sourcegraph" || name == "mcp" {
-				t.Skip("skip network-dependent tool")
+			if name == "patch" || name == "ping" || name == "fetch" || name == "sourcegraph" || name == "mcp" || name == "agent" {
+				t.Skip("skip complex tool")
 			}
 			if name == "edit" {
 				path := ex["path"].(string)


### PR DESCRIPTION
## Summary
- spawn sub-agents from tools via new `SpawnFn` context
- implement the `agent` builtin using a sub-agent
- trace spawned agents through the new context
- document agent tool behaviour
- skip `agent` in cross-platform tests and add dedicated test

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6859f1ae29c08320b3886210cb415ce0