### PR TITLE
Fix Sourcegraph tool to use context

### DIFF
--- a/internal/tool/manifest.go
+++ b/internal/tool/manifest.go
@@ -453,7 +453,11 @@ var builtinMap = map[string]builtinSpec{
 				return "", errors.New("missing query")
 			}
 			url := "https://sourcegraph.com/search?q=" + url.QueryEscape(q) + "&format=json"
-			resp, err := http.Get(url)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+			if err != nil {
+				return "", err
+			}
+			resp, err := http.DefaultClient.Do(req)
 			if err != nil {
 				return "", err
 			}


### PR DESCRIPTION
## Summary
- use `http.NewRequestWithContext` when hitting Sourcegraph
- execute with `http.DefaultClient.Do`

## Testing
- `go test ./...`
- `cd ts-sdk && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859f18abee483208277108a8cf1f504