### PR TITLE
Add multi-agent TUI orchestration

### DIFF
--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/marcodenic/agentry/internal/core"
 	"github.com/marcodenic/agentry/internal/memory"
 	"github.com/marcodenic/agentry/internal/router"
@@ -12,10 +13,37 @@ import (
 func TestNew(t *testing.T) {
 	ag := core.New(router.Rules{{IfContains: []string{""}, Client: nil}}, tool.Registry{}, memory.NewInMemory(), nil, memory.NewInMemoryVector(), nil)
 	m := New(ag)
-	if m.agent != ag {
+	if m.masterAgent != ag {
 		t.Fatalf("agent mismatch")
 	}
-	if len(m.tools.Items()) != 0 {
-		t.Fatalf("expected no tools")
+	if len(m.agents) != 1 {
+		t.Fatalf("expected one agent")
+	}
+}
+
+func TestCommandFlow(t *testing.T) {
+	ag := core.New(router.Rules{{IfContains: []string{""}, Client: nil}}, tool.Registry{}, memory.NewInMemory(), nil, memory.NewInMemoryVector(), nil)
+	m := New(ag)
+
+	m, _ = m.handleCommand("/spawn helper")
+	if len(m.agents) != 2 {
+		t.Fatalf("spawn failed")
+	}
+
+	var newID uuid.UUID
+	for id := range m.agents {
+		if id != ag.ID {
+			newID = id
+		}
+	}
+
+	m, _ = m.handleCommand("/switch " + newID.String()[:8])
+	if m.active != newID {
+		t.Fatalf("switch failed")
+	}
+
+	m, _ = m.handleCommand("/stop " + newID.String()[:8])
+	if m.agents[newID].Status != StatusStopped {
+		t.Fatalf("stop failed")
 	}
 }


### PR DESCRIPTION
## Summary
- refactor `internal/tui/model.go` to support multiple agents
- implement command parsing for `/spawn`, `/switch`, `/stop`, `/converse`
- show agent status in the TUI panel
- update tests for new multi-agent logic

## Testing
- `go test ./...` *(fails: Forbidden fetching modules)*

------
https://chatgpt.com/codex/tasks/task_e_685a05c468d08320a6ad04223a3d57af