### PR TITLE
Implement store cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ session_ttl: 168h
 
 Run the CLI with `--resume-id myrun` to load a snapshot before running and `--save-id myrun` to save state after each run. `--checkpoint-id myrun` continuously saves intermediate steps so sessions can be resumed.
 Expired sessions are pruned automatically by the server based on `session_ttl`.
+Cleanup runs hourly for any configured store backend.
 
 ### 📚 Vector Store
 

--- a/cmd/agentry/main.go
+++ b/cmd/agentry/main.go
@@ -154,12 +154,12 @@ func main() {
 		}
 		// Session cleanup goroutine
 		if dur, err := time.ParseDuration(cfg.SessionTTL); err == nil && dur > 0 {
-			if s, ok := ag.Store.(*memstore.SQLite); ok {
+			if cl, ok := ag.Store.(memstore.Cleaner); ok {
 				go func() {
 					ticker := time.NewTicker(time.Hour)
 					defer ticker.Stop()
 					for range ticker.C {
-						_ = s.Cleanup(context.Background(), "history", dur)
+						_ = cl.Cleanup(context.Background(), "history", dur)
 					}
 				}()
 			}

--- a/pkg/memstore/file.go
+++ b/pkg/memstore/file.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"sync"
+	"time"
 )
 
 // File is a simple JSON-backed store persisted to disk.
@@ -12,6 +13,7 @@ type File struct {
 	path   string
 	mu     sync.RWMutex
 	kv     map[string]map[string][]byte
+	meta   map[string]map[string]int64
 	vector map[string]string
 }
 
@@ -19,10 +21,27 @@ func NewFile(path string) (*File, error) {
 	f := &File{
 		path:   path,
 		kv:     map[string]map[string][]byte{},
+		meta:   map[string]map[string]int64{},
 		vector: map[string]string{},
 	}
 	if b, err := os.ReadFile(path); err == nil {
-		json.Unmarshal(b, &f.kv)
+		var data struct {
+			KV     map[string]map[string][]byte `json:"kv"`
+			Meta   map[string]map[string]int64  `json:"meta"`
+			Vector map[string]string            `json:"vector"`
+		}
+		if err := json.Unmarshal(b, &data); err == nil && data.KV != nil {
+			f.kv = data.KV
+			if data.Meta != nil {
+				f.meta = data.Meta
+			}
+			if data.Vector != nil {
+				f.vector = data.Vector
+			}
+		} else {
+			// legacy format: just kv map
+			_ = json.Unmarshal(b, &f.kv)
+		}
 	} else if !os.IsNotExist(err) {
 		return nil, err
 	}
@@ -30,7 +49,12 @@ func NewFile(path string) (*File, error) {
 }
 
 func (f *File) persist() error {
-	b, err := json.Marshal(f.kv)
+	data := struct {
+		KV     map[string]map[string][]byte `json:"kv"`
+		Meta   map[string]map[string]int64  `json:"meta"`
+		Vector map[string]string            `json:"vector"`
+	}{f.kv, f.meta, f.vector}
+	b, err := json.Marshal(data)
 	if err != nil {
 		return err
 	}
@@ -43,9 +67,13 @@ func (f *File) Set(_ context.Context, bucket, key string, val []byte) error {
 	if f.kv[bucket] == nil {
 		f.kv[bucket] = map[string][]byte{}
 	}
+	if f.meta[bucket] == nil {
+		f.meta[bucket] = map[string]int64{}
+	}
 	cp := make([]byte, len(val))
 	copy(cp, val)
 	f.kv[bucket][key] = cp
+	f.meta[bucket][key] = time.Now().Unix()
 	return f.persist()
 }
 
@@ -82,4 +110,20 @@ func (f *File) Query(_ context.Context, _ string, k int) ([]string, error) {
 		}
 	}
 	return ids, nil
+}
+
+func (f *File) Cleanup(_ context.Context, bucket string, ttl time.Duration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.kv[bucket] == nil {
+		return nil
+	}
+	before := time.Now().Add(-ttl).Unix()
+	for k, ts := range f.meta[bucket] {
+		if ts < before {
+			delete(f.kv[bucket], k)
+			delete(f.meta[bucket], k)
+		}
+	}
+	return f.persist()
 }

--- a/pkg/memstore/inmem.go
+++ b/pkg/memstore/inmem.go
@@ -3,18 +3,21 @@ package memstore
 import (
 	"context"
 	"sync"
+	"time"
 )
 
 // InMemory is a simple ephemeral store backed by Go maps.
 type InMemory struct {
 	mu     sync.RWMutex
 	kv     map[string]map[string][]byte
+	meta   map[string]map[string]int64
 	vector map[string]string
 }
 
 func NewInMemory() *InMemory {
 	return &InMemory{
 		kv:     map[string]map[string][]byte{},
+		meta:   map[string]map[string]int64{},
 		vector: map[string]string{},
 	}
 }
@@ -25,9 +28,13 @@ func (m *InMemory) Set(_ context.Context, bucket, key string, val []byte) error 
 	if m.kv[bucket] == nil {
 		m.kv[bucket] = map[string][]byte{}
 	}
+	if m.meta[bucket] == nil {
+		m.meta[bucket] = map[string]int64{}
+	}
 	cp := make([]byte, len(val))
 	copy(cp, val)
 	m.kv[bucket][key] = cp
+	m.meta[bucket][key] = time.Now().Unix()
 	return nil
 }
 
@@ -64,4 +71,20 @@ func (m *InMemory) Query(_ context.Context, _ string, k int) ([]string, error) {
 		}
 	}
 	return ids, nil
+}
+
+func (m *InMemory) Cleanup(_ context.Context, bucket string, ttl time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.kv[bucket] == nil {
+		return nil
+	}
+	before := time.Now().Add(-ttl).Unix()
+	for k, ts := range m.meta[bucket] {
+		if ts < before {
+			delete(m.kv[bucket], k)
+			delete(m.meta[bucket], k)
+		}
+	}
+	return nil
 }

--- a/pkg/memstore/memstore.go
+++ b/pkg/memstore/memstore.go
@@ -1,6 +1,9 @@
 package memstore
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // KV defines a simple bucketed key/value store.
 type KV interface {
@@ -12,4 +15,9 @@ type KV interface {
 type Vector interface {
 	Add(ctx context.Context, id, text string) error
 	Query(ctx context.Context, text string, k int) ([]string, error)
+}
+
+// Cleaner defines optional TTL-based cleanup for a store.
+type Cleaner interface {
+	Cleanup(ctx context.Context, bucket string, ttl time.Duration) error
 }


### PR DESCRIPTION
## Summary
- add a Cleaner interface for TTL-based garbage collection
- implement Cleanup for in-memory and file stores
- run the cleanup goroutine for any store that implements Cleaner
- update README with info about hourly session pruning

## Testing
- `go test ./...` *(fails: github.com/klauspost/compress download blocked)*
- `npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a074115ac8320b09eded405862ebb