### PR TITLE
Add metrics and OTLP export

### DIFF
--- a/internal/trace/otel.go
+++ b/internal/trace/otel.go
@@ -64,3 +64,16 @@ func (o *OTelWriter) Write(ctx context.Context, e Event) {
 		attribute.String("data", fmt.Sprintf("%v", e.Data)),
 	))
 }
+
+// Export sends a slice of trace events as individual spans using the global tracer.
+func Export(ctx context.Context, events []Event) {
+	tr := otel.Tracer("agentry")
+	for _, e := range events {
+		_, span := tr.Start(ctx, string(e.Type))
+		span.SetAttributes(
+			attribute.String("agent_id", e.AgentID),
+			attribute.String("data", fmt.Sprintf("%v", e.Data)),
+		)
+		span.End()
+	}
+}


### PR DESCRIPTION
## Summary
- instrument HTTP server endpoints with Prometheus metrics
- export trace event slices via OTLP
- show request counts in Svelte dashboard

## Testing
- `go test ./...` *(fails: Forbidden when fetching modules)*
- `cd ts-sdk && npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a061b4b88832081f2e92e6e3c1023