### PR TITLE
Add role templates and team presets

### DIFF
--- a/examples/teams/docs/.agentry.flow.yaml
+++ b/examples/teams/docs/.agentry.flow.yaml
@@ -1,2 +1,7 @@
 presets:
   - docs_team.yaml
+
+agents:
+  writer:
+    vars:
+      personality: friendly

--- a/examples/teams/website/.agentry.flow.yaml
+++ b/examples/teams/website/.agentry.flow.yaml
@@ -1,9 +1,10 @@
 presets:
-  - dev_team.yaml
+  - website_team.yaml
+
 agents:
+  coder:
+    vars:
+      personality: calm
   deployer:
-    model: gpt-4
-    prompt: "Deploy the finished code."
-tasks:
-  - agent: deployer
-    input: deploy application
+    vars:
+      personality: cautious

--- a/templates/dev_team.yaml
+++ b/templates/dev_team.yaml
@@ -1,12 +1,16 @@
+include:
+  - roles/coder.yaml
+  - roles/reviewer.yaml
+
 agents:
   coder:
     model: gpt-4
-    prompt: "You are a pragmatic software developer."
-    tools: [bash, grep, ls, write]
+    vars:
+      personality: pragmatic
   reviewer:
     model: gpt-4
-    prompt: "You review and improve code."
-    tools: [view, echo]
+    vars:
+      personality: nitpicky
 tasks:
   - agent: coder
     input: build feature

--- a/templates/docs_team.yaml
+++ b/templates/docs_team.yaml
@@ -1,10 +1,16 @@
+include:
+  - roles/writer.yaml
+  - roles/editor.yaml
+
 agents:
   writer:
     model: gpt-4
-    prompt: "Write clear documentation."
+    vars:
+      personality: helpful
   editor:
     model: gpt-4
-    prompt: "Polish and edit documentation."
+    vars:
+      personality: precise
 tasks:
   - agent: writer
     input: draft docs

--- a/templates/roles/coder.yaml
+++ b/templates/roles/coder.yaml
@@ -1,6 +1,6 @@
 name: coder
 prompt: |
-  You are an expert software developer who writes clear, concise code.
+  You are an expert software developer with a {{personality}} demeanor who writes clear, concise code.
 tools:
   - bash
   - patch

--- a/templates/roles/deployer.yaml
+++ b/templates/roles/deployer.yaml
@@ -1,0 +1,7 @@
+name: deployer
+prompt: |
+  You deploy applications with a {{personality}} approach, ensuring reliability and minimal downtime.
+tools:
+  - bash
+  - patch
+  - view

--- a/templates/roles/designer.yaml
+++ b/templates/roles/designer.yaml
@@ -1,0 +1,7 @@
+name: designer
+prompt: |
+  You design user interfaces with a {{personality}} style, focusing on usability and aesthetics.
+tools:
+  - draw
+  - view
+  - write

--- a/templates/roles/editor.yaml
+++ b/templates/roles/editor.yaml
@@ -1,0 +1,7 @@
+name: editor
+prompt: |
+  You edit text with a {{personality}} eye for detail, improving clarity and grammar.
+tools:
+  - view
+  - write
+  - patch

--- a/templates/roles/researcher.yaml
+++ b/templates/roles/researcher.yaml
@@ -1,0 +1,7 @@
+name: researcher
+prompt: |
+  You dig into documentation and source code with a {{personality}} curiosity to uncover insights.
+tools:
+  - fetch
+  - grep
+  - view

--- a/templates/roles/reviewer.yaml
+++ b/templates/roles/reviewer.yaml
@@ -1,0 +1,6 @@
+name: reviewer
+prompt: |
+  You review code with a {{personality}} mindset, providing constructive feedback.
+tools:
+  - view
+  - echo

--- a/templates/roles/team_planner.yaml
+++ b/templates/roles/team_planner.yaml
@@ -1,6 +1,7 @@
 # Default system prompt for team mode
+name: planner
 prompt: |
-  You are a project planning assistant. Your job is to:
+  You are a project planning assistant with a {{personality}} demeanor. Your job is to:
   1. Use the available tools to locate and read ROADMAP.md in the workspace.
      - Use the `ls` tool to list files.
      - Use the `view` tool to read file contents.

--- a/templates/roles/tester.yaml
+++ b/templates/roles/tester.yaml
@@ -1,0 +1,7 @@
+name: tester
+prompt: |
+  You thoroughly test code with a {{personality}} mindset, finding edge cases and bugs.
+tools:
+  - bash
+  - view
+  - echo

--- a/templates/roles/writer.yaml
+++ b/templates/roles/writer.yaml
@@ -1,6 +1,6 @@
 name: writer
 prompt: |
-  You craft engaging prose and explain complex topics clearly.
+  You craft engaging prose and explain complex topics clearly with a {{personality}} voice.
 tools:
   - fetch
   - write

--- a/templates/website_team.yaml
+++ b/templates/website_team.yaml
@@ -1,0 +1,33 @@
+include:
+  - roles/coder.yaml
+  - roles/designer.yaml
+  - roles/tester.yaml
+  - roles/deployer.yaml
+
+agents:
+  coder:
+    model: gpt-4
+    vars:
+      personality: efficient
+  designer:
+    model: gpt-4
+    vars:
+      personality: creative
+  tester:
+    model: gpt-4
+    vars:
+      personality: skeptical
+  deployer:
+    model: gpt-4
+    vars:
+      personality: cautious
+
+tasks:
+  - agent: coder
+    input: implement UI
+  - agent: designer
+    input: finalize layout
+  - agent: tester
+    input: run e2e tests
+  - agent: deployer
+    input: deploy application


### PR DESCRIPTION
## Summary
- add a library of role YAML snippets under `templates/roles`
- create a `website_team.yaml` preset and update existing team presets
- demo personality variables in the team example flows

## Testing
- `go test ./...` *(fails: Forbidden fetching module)*
- `cd ts-sdk && npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a06b265188320ac00cda5e0cfc7ca