### PR TITLE
Add tool CLI helpers and plugin registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,13 +419,36 @@ Start the Agentry server with `agentry serve --config examples/.agentry.yaml` th
 
 ## 🔌 Plugin Registry
 
-A sample registry file lives under `examples/registry/index.json`. Each entry lists a plugin
-archive `url` and its expected `sha256` checksum.
-Fetch a plugin with:
+The project publishes a small registry at `docs/registry/plugins.json`. Each
+entry lists a plugin repository URL and description. Fetch a plugin and install
+it with:
 
 ```bash
-agentry plugin fetch examples/registry/index.json example
+agentry plugin fetch docs/registry/plugins.json agentry-shell
+agentry plugin install https://github.com/marcodenic/agentry-shell
 ```
 
-To contribute, add your plugin information to `index.json` and open a pull request.
-See `examples/registry/README.md` for details.
+To contribute a plugin, update `docs/registry/plugins.json` and open a pull
+request.
+
+## 🛠️ Tool Scaffolding
+
+Create boilerplate for a new built-in tool:
+
+```bash
+agentry tool init mytool
+```
+
+This generates a folder with a Go source file and YAML manifest.
+
+## 🔗 Wrapping OpenAPI or MCP Specs
+
+Specs can be converted to tool definitions at the command line:
+
+```bash
+agentry tool openapi examples/echo-openapi.yaml > tools.yaml
+agentry tool mcp examples/ping-mcp.json > tools.yaml
+```
+
+Each command prints YAML `ToolSpec` entries that can be inspected or embedded in
+config files.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -444,10 +444,10 @@ Agentry aims to become a best-in-class platform for multi-agent AI by anticipati
 
 | ID  |  ‑ [ ] Task                    | Why             | How                           | Deps |
 | --- | ------------------------------ | --------------- | ----------------------------- | ---- |
-| 6.1 | `agentry tool init` scaffolder | Fast plugin dev | Gen skeleton + manifest       | —    |
+| 6.1 | `agentry tool init` scaffolder | Fast plugin dev | Gen skeleton + manifest       | —    | ✅
 | 6.2 | Community registry site        | Discovery       | Static Jamstack index         |  6.1 |
-| 6.3 | Plugin installer CLI           | Easy add        | `install <repo>` updates YAML |  6.2 |
-| 6.4 | OpenAPI/MCP adapter            | Interop         | Wrap external spec as tool    |  6.3 |
+| 6.3 | Plugin installer CLI           | Easy add        | `install <repo>` updates YAML |  6.2 | ✅
+| 6.4 | OpenAPI/MCP adapter            | Interop         | Wrap external spec as tool    |  6.3 | ✅
 
 ## ❼ Observability & Telemetry (ops)
 

--- a/cmd/agentry/plugin.go
+++ b/cmd/agentry/plugin.go
@@ -36,24 +36,3 @@ func runPluginCmd(args []string) {
 		os.Exit(1)
 	}
 }
-
-func runToolCmd(args []string) {
-	if len(args) == 0 {
-		fmt.Println("Usage: agentry tool <command> [args]")
-		os.Exit(1)
-	}
-	switch args[0] {
-	case "init":
-		if len(args) < 2 {
-			fmt.Println("Usage: agentry tool init <name>")
-			os.Exit(1)
-		}
-		if err := plugin.InitTool(args[1]); err != nil {
-			fmt.Printf("init failed: %v\n", err)
-			os.Exit(1)
-		}
-	default:
-		fmt.Printf("unknown tool command %s\n", args[0])
-		os.Exit(1)
-	}
-}

--- a/cmd/agentry/tool.go
+++ b/cmd/agentry/tool.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/marcodenic/agentry/internal/plugin"
+	"github.com/marcodenic/agentry/internal/tool"
+	"gopkg.in/yaml.v3"
+)
+
+func runToolCmd(args []string) {
+	if len(args) == 0 {
+		fmt.Println("Usage: agentry tool <command> [args]")
+		os.Exit(1)
+	}
+	switch args[0] {
+	case "init":
+		if len(args) < 2 {
+			fmt.Println("Usage: agentry tool init <name>")
+			os.Exit(1)
+		}
+		if err := plugin.InitTool(args[1]); err != nil {
+			fmt.Printf("init failed: %v\n", err)
+			os.Exit(1)
+		}
+	case "openapi":
+		if len(args) < 2 {
+			fmt.Println("Usage: agentry tool openapi <spec.yaml>")
+			os.Exit(1)
+		}
+		data, err := os.ReadFile(args[1])
+		if err != nil {
+			fmt.Printf("read spec: %v\n", err)
+			os.Exit(1)
+		}
+		reg, err := tool.FromOpenAPI(data)
+		if err != nil {
+			fmt.Printf("parse spec: %v\n", err)
+			os.Exit(1)
+		}
+		specs := tool.BuildSpecs(reg)
+		b, _ := yaml.Marshal(specs)
+		os.Stdout.Write(b)
+	case "mcp":
+		if len(args) < 2 {
+			fmt.Println("Usage: agentry tool mcp <spec.json>")
+			os.Exit(1)
+		}
+		data, err := os.ReadFile(args[1])
+		if err != nil {
+			fmt.Printf("read spec: %v\n", err)
+			os.Exit(1)
+		}
+		reg, err := tool.FromMCP(data)
+		if err != nil {
+			fmt.Printf("parse spec: %v\n", err)
+			os.Exit(1)
+		}
+		specs := tool.BuildSpecs(reg)
+		b, _ := yaml.Marshal(specs)
+		os.Stdout.Write(b)
+	default:
+		fmt.Printf("unknown tool command %s\n", args[0])
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary
- add `cmd/agentry/tool.go` with new `openapi` and `mcp` commands
- document plugin registry and tool scaffolding
- mark roadmap tasks complete

## Testing
- `npm install` and `npm test` in `ts-sdk`
- `go test ./...` *(fails: storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685a063dd4ac8320a5ff1ab6fa44c07e