### PR TITLE
Update TUI usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The new `tui` command launches a split-screen interface:
 +-------+-----------------------------+
 ```
 
-Run `agentry tui --config examples/.agentry.yaml` to try. Use `--team 3` to launch team chat mode where each agent has its own pane.
+Run `agentry tui --config examples/.agentry.yaml` to start the interface. There is no separate `--team` flag; simply type `/spawn <name>` to add a new agent pane. For example, `/spawn coder` starts an additional "coder" agent. All agents share the same chat window and can be dispatched to remote nodes in your Agentry cluster.
 
 ---
 
@@ -275,13 +275,21 @@ node -e "const {invoke}=require('./dist/index.js');invoke('hi',{stream:false,age
 
 ### 🤖 Multi-agent conversations
 
-The `converse` command spawns multiple sub-agents that riff off one another. This was originally REPL-only, but the TUI now supports team chat via `--team`.
+The `converse` command spawns multiple sub-agents that riff off one another. This was originally REPL-only, but the TUI now supports these conversations without any special flags.
 
 ```bash
 converse 3 Pick a favourite movie, just one, then discuss as a group.
 ```
 
 The first number selects how many agents join the chat. Any remaining text becomes the opening message. If omitted, a generic greeting is used.
+
+Inside the TUI, you can create additional agents on the fly:
+
+```bash
+/spawn researcher "gather background info"
+```
+
+Agents spawned in this way can run tasks locally or on remote nodes connected to your Agentry cluster.
 
 ### 💾 Saving & Resuming
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,6 +39,22 @@ agentry flow examples/flows/multi_agent_chat
 Pass `--resume-id name` to load a saved session and `--save-id name` to persist after each run.
 Use `--checkpoint-id name` to continuously snapshot the run loop and resume after a crash.
 
+### Terminal UI
+
+Start the interactive interface:
+
+```bash
+agentry tui --config examples/.agentry.yaml
+```
+
+There is no `--team` flag. From inside the chat you can spawn additional agents at any time:
+
+```bash
+/spawn coder "handle all build tasks"
+```
+
+Spawned agents appear in their own panes and may run on remote nodes if your Agentry cluster is configured.
+
 ### TUI Themes & Keybinds
 
 Create a `theme.json` file to customise colours and keyboard shortcuts. Agentry looks for the file in the current directory and its parents, falling back to `$HOME/.config/agentry/theme.json`.


### PR DESCRIPTION
## Summary
- document TUI usage in README and docs/usage
- mention spawning agents from the chat instead of `--team`

## Testing
- `go test ./...` *(fails: Forbidden storage.googleapis.com)*
- `cd ts-sdk && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a1e5314408320bfc5bd4a70a1f4e9