### PR TITLE
Refactor team context helpers

### DIFF
--- a/internal/converse/team.go
+++ b/internal/converse/team.go
@@ -9,16 +9,20 @@ import (
 	"github.com/marcodenic/agentry/internal/memory"
 	"github.com/marcodenic/agentry/internal/model"
 	"github.com/marcodenic/agentry/internal/router"
-	"github.com/marcodenic/agentry/internal/teamctx"
+	"github.com/marcodenic/agentry/internal/team"
 )
 
 func contextWithTeam(ctx context.Context, t *Team) context.Context {
-	return context.WithValue(ctx, teamctx.Key{}, t)
+	return team.WithContext(ctx, t)
 }
 
 // TeamFromContext extracts a Team pointer if present.
 func TeamFromContext(ctx context.Context) (*Team, bool) {
-	t, ok := ctx.Value(teamctx.Key{}).(*Team)
+	caller, ok := team.FromContext(ctx)
+	if !ok {
+		return nil, false
+	}
+	t, ok := caller.(*Team)
 	return t, ok
 }
 

--- a/internal/teamctx/key.go
+++ b/internal/teamctx/key.go
@@ -1,4 +1,0 @@
-package teamctx
-
-// Key is the context key used to store a *converse.Team.
-type Key struct{}

--- a/internal/tui/team.go
+++ b/internal/tui/team.go
@@ -9,7 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/marcodenic/agentry/internal/converse"
 	"github.com/marcodenic/agentry/internal/core"
-	"github.com/marcodenic/agentry/internal/teamctx"
+	"github.com/marcodenic/agentry/internal/team"
 )
 
 type teamMsg struct {
@@ -52,7 +52,7 @@ func (m TeamModel) Init() tea.Cmd {
 
 func (m TeamModel) stepCmd() tea.Cmd {
 	return func() tea.Msg {
-		ctx := context.WithValue(context.Background(), teamctx.Key{}, m.team)
+		ctx := team.WithContext(context.Background(), m.team)
 		idx, out, err := m.team.Step(ctx)
 		if err != nil {
 			return errMsg{err}

--- a/tests/agent_tool_context_test.go
+++ b/tests/agent_tool_context_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/marcodenic/agentry/internal/memory"
 	"github.com/marcodenic/agentry/internal/model"
 	"github.com/marcodenic/agentry/internal/router"
-	"github.com/marcodenic/agentry/internal/teamctx"
+	"github.com/marcodenic/agentry/internal/team"
 	"github.com/marcodenic/agentry/internal/tool"
 )
 
@@ -27,7 +27,7 @@ func TestAgentToolContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	ctx := context.WithValue(context.Background(), teamctx.Key{}, team)
+	ctx := team.WithContext(context.Background(), team)
 	tl, ok := tool.DefaultRegistry()["agent"]
 	if !ok {
 		t.Fatalf("agent tool missing")

--- a/tests/agent_tool_test.go
+++ b/tests/agent_tool_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/marcodenic/agentry/internal/memory"
 	"github.com/marcodenic/agentry/internal/model"
 	"github.com/marcodenic/agentry/internal/router"
-	"github.com/marcodenic/agentry/internal/teamctx"
+	"github.com/marcodenic/agentry/internal/team"
 	"github.com/marcodenic/agentry/internal/tool"
 )
 
@@ -32,7 +32,7 @@ func newTestTeam(t *testing.T, reply string) *converse.Team {
 
 func TestAgentToolDelegates(t *testing.T) {
 	tm := newTestTeam(t, "ok")
-	ctx := context.WithValue(context.Background(), teamctx.Key{}, tm)
+	ctx := team.WithContext(context.Background(), tm)
 	tl, ok := tool.DefaultRegistry().Use("agent")
 	if !ok {
 		t.Fatal("agent tool missing")
@@ -48,7 +48,7 @@ func TestAgentToolDelegates(t *testing.T) {
 
 func TestAgentToolUnknown(t *testing.T) {
 	tm := newTestTeam(t, "ignore")
-	ctx := context.WithValue(context.Background(), teamctx.Key{}, tm)
+	ctx := team.WithContext(context.Background(), tm)
 	tl, _ := tool.DefaultRegistry().Use("agent")
 	_, err := tl.Execute(ctx, map[string]any{"agent": "Bogus", "input": "hi"})
 	if err == nil {

--- a/tests/builtin_cross_test.go
+++ b/tests/builtin_cross_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/marcodenic/agentry/internal/memory"
 	"github.com/marcodenic/agentry/internal/model"
 	"github.com/marcodenic/agentry/internal/router"
-	"github.com/marcodenic/agentry/internal/teamctx"
+	"github.com/marcodenic/agentry/internal/team"
 	"github.com/marcodenic/agentry/internal/tool"
 )
 
@@ -30,7 +30,7 @@ func TestBuiltinsCrossPlatform(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create team: %v", err)
 	}
-	ctx := context.WithValue(context.Background(), teamctx.Key{}, team)
+	ctx := team.WithContext(context.Background(), team)
 	for name, tl := range tool.DefaultRegistry() {
 		ex, _ := tl.JSONSchema()["example"].(map[string]any)
 		if ex == nil {


### PR DESCRIPTION
## Summary
- unify context helpers under `internal/team`
- update usage across runtime, TUI, tools and tests
- remove old `teamctx` package

## Testing
- `go test ./...` *(fails: module downloads blocked)*
- `cd ts-sdk && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a1ea7fb3083209b458aa523c00f53