### PR TITLE
Unify TUI models with ChatModel

### DIFF
--- a/cmd/agentry/main.go
+++ b/cmd/agentry/main.go
@@ -296,19 +296,17 @@ func main() {
 		if *resumeID != "" {
 			_ = ag.LoadState(context.Background(), *resumeID)
 		}
-		if *teamSize > 1 {
-			tm, err := tui.NewTeam(ag, *teamSize, *topic)
-			if err != nil {
-				panic(err)
-			}
-			p := tea.NewProgram(tm)
-			if err := p.Start(); err != nil {
-				panic(err)
-			}		} else {
-			p := tea.NewProgram(tui.New(ag))
-			if err := p.Start(); err != nil {
-				panic(err)
-			}
+		size := 1
+		if *teamSize > 0 {
+			size = *teamSize
+		}
+		cm, err := tui.NewChat(ag, size, *topic)
+		if err != nil {
+			panic(err)
+		}
+		p := tea.NewProgram(cm)
+		if err := p.Start(); err != nil {
+			panic(err)
 		}
 		if *saveID != "" {
 			_ = ag.SaveState(context.Background(), *saveID)

--- a/internal/tui/chat.go
+++ b/internal/tui/chat.go
@@ -1,0 +1,226 @@
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/google/uuid"
+	"github.com/marcodenic/agentry/internal/converse"
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/teamctx"
+)
+
+// ChatModel is a unified model that manages a converse.Team of any size.
+type ChatModel struct {
+	parent *core.Agent
+	team   *converse.Team
+	infos  map[uuid.UUID]*AgentInfo
+	names  []string
+	active uuid.UUID
+
+	vps    []viewport.Model
+	input  textinput.Model
+	width  int
+	height int
+
+	theme Theme
+	keys  Keybinds
+	err   error
+}
+
+// NewChat creates a team with n agents talking about topic.
+func NewChat(parent *core.Agent, n int, topic string) (ChatModel, error) {
+	th := LoadTheme()
+	t, err := converse.NewTeam(parent, n, topic)
+	if err != nil {
+		return ChatModel{}, err
+	}
+	vps := make([]viewport.Model, n)
+	infos := make(map[uuid.UUID]*AgentInfo, n)
+	for i, ag := range t.Agents() {
+		vps[i] = viewport.New(0, 0)
+		infos[ag.ID] = &AgentInfo{Agent: ag, Status: StatusIdle, Name: t.Names()[i]}
+	}
+	ti := textinput.New()
+	ti.Placeholder = "Message"
+	ti.Focus()
+	return ChatModel{parent: parent, team: t, infos: infos, names: t.Names(), active: t.Agents()[0].ID,
+		vps: vps, input: ti, theme: th, keys: th.Keybinds}, nil
+}
+
+func (m ChatModel) Init() tea.Cmd { return nil }
+
+// Update handles Bubble Tea messages.
+func (m ChatModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case m.keys.Quit:
+			return m, tea.Quit
+		case m.keys.Submit:
+			if m.input.Focused() {
+				txt := m.input.Value()
+				m.input.SetValue("")
+				if strings.HasPrefix(txt, "/") {
+					var cmd tea.Cmd
+					m, cmd = m.handleCommand(txt)
+					return m, cmd
+				}
+				return m.callActive(txt)
+			}
+		}
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		for i := range m.vps {
+			m.vps[i].Width = int(float64(msg.Width)*0.75) - 2
+			m.vps[i].Height = msg.Height - 5
+			if info, ok := m.infos[m.team.Agents()[i].ID]; ok {
+				m.vps[i].SetContent(info.History)
+			}
+		}
+	}
+
+	m.input, _ = m.input.Update(msg)
+	return m, nil
+}
+
+func (m ChatModel) View() string {
+	vp := viewport.Model{}
+	if info, ok := m.infos[m.active]; ok {
+		vp = m.vps[m.indexOf(m.active)]
+		vp.SetContent(info.History)
+	}
+	main := vp.View() + "\n" + m.input.View()
+	footer := fmt.Sprintf("agents: %d", len(m.infos))
+	return fmt.Sprintf("%s\n%s", main, footer)
+}
+
+func (m ChatModel) indexOf(id uuid.UUID) int {
+	for i, ag := range m.team.Agents() {
+		if ag.ID == id {
+			return i
+		}
+	}
+	return 0
+}
+
+func (m ChatModel) callActive(input string) (ChatModel, tea.Cmd) {
+	agName := m.names[m.indexOf(m.active)]
+	info := m.infos[m.active]
+	info.History += m.userBar() + " " + input + "\n"
+	ctx := context.WithValue(context.Background(), teamctx.Key{}, m.team)
+	out, err := m.team.Call(ctx, agName, input)
+	if err != nil {
+		m.err = err
+		return m, nil
+	}
+	info.History += m.aiBar() + " " + out + "\n"
+	m.infos[m.active] = info
+	idx := m.indexOf(m.active)
+	m.vps[idx].SetContent(info.History)
+	m.vps[idx].GotoBottom()
+	return m, nil
+}
+
+func (m ChatModel) handleCommand(cmd string) (ChatModel, tea.Cmd) {
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return m, nil
+	}
+	switch fields[0] {
+	case "/spawn":
+		return m.handleSpawn(fields[1:])
+	case "/switch":
+		return m.handleSwitch(fields[1:])
+	case "/stop":
+		return m.handleStop(fields[1:])
+	case "/converse":
+		return m.handleConverse(fields[1:])
+	default:
+		return m, nil
+	}
+}
+
+func (m ChatModel) handleSpawn(args []string) (ChatModel, tea.Cmd) {
+	name := ""
+	if len(args) > 0 {
+		name = args[0]
+	}
+	ag, nm := m.team.AddAgent(name)
+	m.names = append(m.names, nm)
+	m.infos[ag.ID] = &AgentInfo{Agent: ag, Status: StatusIdle, Name: nm}
+	vp := viewport.New(0, 0)
+	m.vps = append(m.vps, vp)
+	m.active = ag.ID
+	return m, nil
+}
+
+func (m ChatModel) handleSwitch(args []string) (ChatModel, tea.Cmd) {
+	if len(args) == 0 {
+		return m, nil
+	}
+	pref := args[0]
+	for id := range m.infos {
+		if strings.HasPrefix(id.String(), pref) {
+			m.active = id
+			break
+		}
+	}
+	return m, nil
+}
+
+func (m ChatModel) handleStop(args []string) (ChatModel, tea.Cmd) {
+	// No asynchronous runs in this simplified model, but keep status field.
+	id := m.active
+	if len(args) > 0 {
+		pref := args[0]
+		for aid := range m.infos {
+			if strings.HasPrefix(aid.String(), pref) {
+				id = aid
+				break
+			}
+		}
+	}
+	if info, ok := m.infos[id]; ok {
+		info.Status = StatusStopped
+		m.infos[id] = info
+	}
+	return m, nil
+}
+
+func (m ChatModel) handleConverse(args []string) (ChatModel, tea.Cmd) {
+	// Kick off a round-robin conversation using the existing team.
+	ctx := context.WithValue(context.Background(), teamctx.Key{}, m.team)
+	idx, out, err := m.team.Step(ctx)
+	if err != nil {
+		m.err = err
+		return m, nil
+	}
+	ag := m.team.Agents()[idx]
+	info := m.infos[ag.ID]
+	info.History += m.aiBar() + " " + out + "\n"
+	m.infos[ag.ID] = info
+	m.vps[idx].SetContent(info.History)
+	m.vps[idx].GotoBottom()
+	return m, nil
+}
+
+var _ tea.Model = ChatModel{}
+
+// Helpers copied from model.go
+func (m ChatModel) userBar() string {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(m.theme.UserBarColor)).Render("┃")
+}
+
+func (m ChatModel) aiBar() string {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(m.theme.AIBarColor)).Render("┃")
+}
+
+// Agents exposes the team's agents for tests.
+func (m ChatModel) Agents() map[uuid.UUID]*AgentInfo { return m.infos }

--- a/internal/tui/team_test.go
+++ b/internal/tui/team_test.go
@@ -11,11 +11,11 @@ import (
 
 func TestNewTeam(t *testing.T) {
 	ag := core.New(router.Rules{{IfContains: []string{""}, Client: nil}}, tool.Registry{}, memory.NewInMemory(), nil, memory.NewInMemoryVector(), nil)
-	tm, err := NewTeam(ag, 2, "")
+	cm, err := NewChat(ag, 2, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(tm.vps) != 2 {
+	if len(cm.vps) != 2 {
 		t.Fatalf("expected 2 panes")
 	}
 }


### PR DESCRIPTION
## Summary
- add `ChatModel` for single and multi-agent chat
- expose helper methods and `AddAgent` on `converse.Team`
- use `ChatModel` from `agentry` CLI
- update tests for new model

## Testing
- `go test ./...` *(fails: fetch forbidden)*
- `cd ts-sdk && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a1eadd6348320a1cddb4b55163f34