### PR TITLE
Add design doc details and cross links

### DIFF
--- a/README-cloud.md
+++ b/README-cloud.md
@@ -40,6 +40,14 @@ flowchart LR
 
 This layout may evolve as the distributed scheduler and sandbox features mature.
 
+## Design Documents
+
+Further design notes live in the `design/` directory:
+
+- [Distributed Architecture](design/distributed_arch.md)
+- [Flow DSL](design/flow_dsl.md)
+- [Sandbox Architecture](design/sandbox.md)
+
 ## Building the Dashboard
 
 The web dashboard lives under `ui/web` and uses SvelteKit.

--- a/design/distributed_arch.md
+++ b/design/distributed_arch.md
@@ -1,3 +1,44 @@
 # Distributed Architecture
 
-High-level approach for scaling Agentry across multiple nodes and workers.
+Agentry Cloud uses a hub-and-node model that coordinates work across multiple services. This layout allows agent tasks to scale horizontally while keeping the runtime lightweight.
+
+## Components
+
+- **Hub** – central gRPC/HTTP service responsible for accepting requests, storing agent templates and publishing work to the queue.
+- **Nodes** – workers that subscribe to the queue and execute agent steps. Nodes are stateless and can scale up or down.
+- **Worker Processes** – optional long‑running jobs that handle CPU/GPU intensive operations.
+- **NATS** – message bus used for task scheduling and broadcast events.
+- **Persistent Storage** – database or object store for agent state, traces and logs.
+
+## Workflow
+
+1. A client calls the hub to `spawn` or `invoke` an agent.
+2. The hub stores metadata and publishes a task on NATS.
+3. An available node pulls the task and runs the agent step.
+4. Results are sent back through the hub and persisted.
+5. Heavy tasks may be offloaded to dedicated worker processes.
+
+```mermaid
+flowchart TB
+    Client --> Hub
+    Hub --> NATS
+    NATS --> Node1(Node)
+    NATS --> Node2(Node)
+    Node1 --> Worker
+    Node2 --> Worker
+    Hub --> Storage
+    Worker --> Storage
+    subgraph Nodes
+        Node1
+        Node2
+    end
+```
+
+## Scaling
+
+- Add more nodes to increase concurrency; they connect automatically to NATS and the hub.
+- Use NATS queue groups to distribute tasks evenly.
+- Workers can be specialised for GPU tasks or sandboxed execution.
+- The hub remains mostly stateless so it can be replicated behind a load balancer.
+
+

--- a/design/flow_dsl.md
+++ b/design/flow_dsl.md
@@ -1,3 +1,52 @@
 # Flow DSL
 
-Initial notes on a declarative Domain Specific Language for orchestrating agent workflows.
+The Flow DSL provides a declarative way to orchestrate multi-step agent workflows using YAML files. A flow is executed with `agentry flow <path>` and may spawn additional agents or call tools in sequence.
+
+## Goals
+
+- **Declarative** – describe prompts and tool usage without writing Go code.
+- **Composable** – steps can include sub-flows or spawn new agents.
+- **Portable** – YAML definitions can be shared and version controlled.
+
+## Basic Structure
+
+```yaml
+steps:
+  - prompt: |
+      You are a research assistant. Summarise the topic.
+    tool: web-search
+    assign: search
+  - if: search.results
+    spawn: summariser
+  - parallel:
+      - { tool: summariser, input: "{{search.results}}" }
+      - { tool: translator, input: "{{search.summary}}" }
+  - end
+```
+
+## Execution Workflow
+
+1. The CLI parses the YAML into a `FlowSpec`.
+2. Each `step` is executed sequentially unless a `parallel` block is encountered.
+3. Output from steps is stored in a context and referenced via `{{ placeholders }}`.
+4. `spawn` steps run sub-agents concurrently and merge their results back into the flow context.
+
+```mermaid
+flowchart TD
+    Start --> Parse
+    Parse --> Step1[Step 1]
+    Step1 --> Step2[Step 2]
+    Step2 -->|parallel| Step3A[Step 3A]
+    Step2 -->|parallel| Step3B[Step 3B]
+    Step3A --> Step4[Step 4]
+    Step3B --> Step4
+    Step4 --> End
+```
+
+## Future Features
+
+- Conditionals (`if`, `unless`) for branching logic.
+- Loop constructs for iterative tasks.
+- Integration with the distributed scheduler so steps can run on remote nodes.
+
+

--- a/design/sandbox.md
+++ b/design/sandbox.md
@@ -1,3 +1,42 @@
 # Sandbox Architecture
 
-Overview of execution sandboxing for secure tool and plugin isolation.
+Tools and plugins may execute untrusted code. The sandbox isolates these processes from the host system while still allowing them to interact with the agent runtime.
+
+## Goals
+
+- **Security** – prevent malicious code from affecting the rest of the system.
+- **Reproducibility** – run tools in clean environments with limited side effects.
+- **Flexibility** – support local OS sandboxes or container runtimes.
+
+## Approach
+
+1. The agent launches a sandbox process with the desired command.
+2. A restricted working directory is created and mounted as the tool's root.
+3. Syscall filtering (seccomp) and read‑only mounts limit access to the host.
+4. Network access can be disabled or proxied through the hub.
+5. Output is streamed back to the agent and then to the client.
+
+```mermaid
+flowchart LR
+    Agent -->|exec| Sandbox
+    Sandbox --> ToolProcess
+    ToolProcess -->|stdout| Sandbox
+    Sandbox --> Agent
+    subgraph Isolation
+        Sandbox
+    end
+```
+
+## Typical Workflow
+
+1. Agent prepares the tool command and allowed files.
+2. Sandbox initialises the environment, applying cgroups or container limits.
+3. The tool runs to completion; stdout and stderr are captured.
+4. Results are returned and the temporary directory is removed.
+
+## Future Work
+
+- Policy engine for per-tool permissions.
+- Remote sandbox execution on specialised worker nodes.
+
+


### PR DESCRIPTION
## Summary
- flesh out the distributed architecture document
- expand Flow DSL documentation
- outline sandbox architecture
- link design documents from cloud README

## Testing
- `go test ./...` *(fails: Forbidden retrieving modules)*
- `cd ts-sdk && npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a22a441d483208247227a099ace04