### PR TITLE
Add multi-agent UI and conversation tests

### DIFF
--- a/demos/demo_branch_tidy.go
+++ b/demos/demo_branch_tidy.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (
@@ -17,11 +19,11 @@ func main() {
 
 	fmt.Println("=== Branch Tidy Tool Demo ===")
 	fmt.Println("\nTool Description:", branchTidy.Description())
-	
+
 	schema := branchTidy.JSONSchema()
 	fmt.Println("\nTool Schema:")
 	fmt.Printf("  Type: %v\n", schema["type"])
-	
+
 	if props, ok := schema["properties"].(map[string]any); ok {
 		fmt.Println("  Properties:")
 		for name, prop := range props {

--- a/demos/test_registry.go
+++ b/demos/test_registry.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/internal/teamctx/key.go
+++ b/internal/teamctx/key.go
@@ -1,0 +1,3 @@
+package teamctx
+
+type Key struct{}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,11 +1,17 @@
 package tui
 
 import (
+	"context"
+	"fmt"
+	"strings"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/google/uuid"
 	"github.com/marcodenic/agentry/internal/core"
 	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/model"
 	"github.com/marcodenic/agentry/internal/router"
 	"github.com/marcodenic/agentry/internal/tool"
 )
@@ -48,5 +54,59 @@ func TestCommandFlow(t *testing.T) {
 	m, _ = m.handleCommand("/stop " + newID.String()[:8])
 	if m.infos[newID].Status != StatusStopped {
 		t.Fatalf("stop failed")
+	}
+}
+
+type seqMock struct{ n int }
+
+func (m *seqMock) Complete(ctx context.Context, msgs []model.ChatMessage, tools []model.ToolSpec) (model.Completion, error) {
+	m.n++
+	return model.Completion{Content: fmt.Sprintf("msg%d", m.n)}, nil
+}
+
+func TestChatModelMultipleAgents(t *testing.T) {
+	mock := &seqMock{}
+	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: mock}}
+	ag := core.New(route, tool.Registry{}, memory.NewInMemory(), nil, memory.NewInMemoryVector(), nil)
+
+	m, err := NewChat(ag, 1, "")
+	if err != nil {
+		t.Fatalf("new chat error: %v", err)
+	}
+
+	m, _ = m.handleCommand("/spawn second")
+	m, _ = m.handleCommand("/spawn third")
+	if len(m.infos) != 3 {
+		t.Fatalf("expected 3 agents got %d", len(m.infos))
+	}
+
+	var secondID uuid.UUID
+	for id, info := range m.infos {
+		if info.Name == "second" {
+			secondID = id
+			break
+		}
+	}
+	if secondID == uuid.Nil {
+		t.Fatal("second agent not found")
+	}
+
+	m, _ = m.handleCommand("/switch " + secondID.String()[:8])
+	if m.active != secondID {
+		t.Fatalf("switch failed")
+	}
+
+	// simulate window sizing so viewport renders
+	nm, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
+	m = nm.(ChatModel)
+
+	m, _ = m.callActive("ping")
+	hist := m.infos[secondID].History
+	if !strings.Contains(hist, "ping") {
+		t.Fatalf("history missing input: %s", hist)
+	}
+	view := m.vps[m.indexOf(secondID)].View()
+	if !strings.Contains(view, "msg1") {
+		t.Fatalf("viewport not updated: %s", view)
 	}
 }

--- a/tests/agent_tool_context_test.go
+++ b/tests/agent_tool_context_test.go
@@ -23,11 +23,11 @@ func (agentMock) Complete(ctx context.Context, msgs []model.ChatMessage, tools [
 func TestAgentToolContext(t *testing.T) {
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: agentMock{}}}
 	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), nil)
-	team, err := converse.NewTeam(ag, 1, "hi")
+	tm, err := converse.NewTeam(ag, 1, "hi")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	ctx := team.WithContext(context.Background(), team)
+	ctx := team.WithContext(context.Background(), tm)
 	tl, ok := tool.DefaultRegistry()["agent"]
 	if !ok {
 		t.Fatalf("agent tool missing")

--- a/tests/builtin_cross_test.go
+++ b/tests/builtin_cross_test.go
@@ -26,11 +26,11 @@ func TestBuiltinsCrossPlatform(t *testing.T) {
 	// Set up team context for agent tool
 	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: simpleMock{}}}
 	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), nil, memory.NewInMemoryVector(), nil)
-	team, err := converse.NewTeam(ag, 1, "test")
+	tm, err := converse.NewTeam(ag, 1, "test")
 	if err != nil {
 		t.Fatalf("failed to create team: %v", err)
 	}
-	ctx := team.WithContext(context.Background(), team)
+	ctx := team.WithContext(context.Background(), tm)
 	for name, tl := range tool.DefaultRegistry() {
 		ex, _ := tl.JSONSchema()["example"].(map[string]any)
 		if ex == nil {

--- a/tests/converse_team_integration_test.go
+++ b/tests/converse_team_integration_test.go
@@ -1,0 +1,45 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/converse"
+	"github.com/marcodenic/agentry/internal/core"
+	"github.com/marcodenic/agentry/internal/memory"
+	"github.com/marcodenic/agentry/internal/model"
+	"github.com/marcodenic/agentry/internal/router"
+)
+
+type seqTeamMock struct{ n int }
+
+func (m *seqTeamMock) Complete(ctx context.Context, msgs []model.ChatMessage, tools []model.ToolSpec) (model.Completion, error) {
+	m.n++
+	return model.Completion{Content: fmt.Sprintf("msg%d", m.n)}, nil
+}
+
+func TestTeamSpawnConversation(t *testing.T) {
+	mock := &seqTeamMock{}
+	route := router.Rules{{Name: "mock", IfContains: []string{""}, Client: mock}}
+	parent := core.New(route, nil, memory.NewInMemory(), nil, memory.NewInMemoryVector(), nil)
+	tm, err := converse.NewTeam(parent, 2, "hi")
+	if err != nil {
+		t.Fatalf("new team: %v", err)
+	}
+	ctx := context.Background()
+	idx, out, err := tm.Step(ctx)
+	if err != nil {
+		t.Fatalf("step1 error: %v", err)
+	}
+	if idx != 0 || out != "msg1" {
+		t.Fatalf("turn1 expected agent0 msg1 got idx %d %s", idx, out)
+	}
+	idx, out, err = tm.Step(ctx)
+	if err != nil {
+		t.Fatalf("step2 error: %v", err)
+	}
+	if idx != 1 || out != "msg2" {
+		t.Fatalf("turn2 expected agent1 msg2 got idx %d %s", idx, out)
+	}
+}


### PR DESCRIPTION
## Summary
- add ignored build tags to demo programs so tests compile
- introduce `teamctx` package with context key
- improve command/UI tests for chat model
- add team conversation integration test
- fix team context tests

## Testing
- `go test ./...` *(fails: branch tidy, flow parser, metrics endpoint)*
- `cd ts-sdk && npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a23ad173083208411e7ea3bd2f22b