### PR TITLE
Add configurable OTLP collector

### DIFF
--- a/cmd/agentry/main.go
+++ b/cmd/agentry/main.go
@@ -173,7 +173,7 @@ func main() {
 		if *resumeID != "" {
 			_ = ag.LoadState(context.Background(), *resumeID)
 		}
-		if cfg.Metrics {
+		if cfg.Collector != "" {
 			if _, err := trace.Init(cfg.Collector); err != nil {
 				fmt.Printf("trace init: %v\n", err)
 			}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,6 +149,13 @@ metrics: true
 collector: localhost:4318
 ```
 
+You can override the collector address via the `AGENTRY_COLLECTOR` environment
+variable:
+
+```bash
+export AGENTRY_COLLECTOR=collector.example.com:4318
+```
+
 The server then exposes `/metrics` and streams spans to the specified collector.
 
 ## Plugin Management

--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,9 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/sourcegraph/go-diff v0.7.0
 	go.opentelemetry.io/otel v1.36.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.36.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.22.0
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.36.0
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.36.0
+go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.22.0
 	go.opentelemetry.io/otel/sdk v1.36.0
 	go.opentelemetry.io/otel/trace v1.36.0
 	go.opentelemetry.io/proto/otlp v1.7.0

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -157,5 +157,8 @@ func Load(path string) (*File, error) {
 		return nil, err
 	}
 	merge(&out, yamlFile)
+	if v := os.Getenv("AGENTRY_COLLECTOR"); v != "" {
+		out.Collector = v
+	}
 	return &out, nil
 }

--- a/internal/trace/otel.go
+++ b/internal/trace/otel.go
@@ -7,6 +7,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -26,9 +27,11 @@ func Init(collector string) (func(context.Context) error, error) {
 		if strings.HasPrefix(addr, "http://") {
 			addr = strings.TrimPrefix(addr, "http://")
 		}
-		exp, err = otlptracehttp.New(ctx,
+		client := otlptracehttp.NewClient(
 			otlptracehttp.WithEndpoint(addr),
-			otlptracehttp.WithInsecure())
+			otlptracehttp.WithInsecure(),
+		)
+		exp, err = otlptrace.New(ctx, client)
 	} else {
 		exp, err = stdouttrace.New(stdouttrace.WithPrettyPrint())
 	}

--- a/tests/trace_test.go
+++ b/tests/trace_test.go
@@ -1,0 +1,24 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/config"
+)
+
+func TestCollectorEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/conf.yaml"
+	os.WriteFile(path, []byte("metrics: true\n"), 0644)
+	os.Setenv("AGENTRY_COLLECTOR", "127.0.0.1:4318")
+	defer os.Unsetenv("AGENTRY_COLLECTOR")
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Collector != "127.0.0.1:4318" {
+		t.Fatalf("collector not overridden: %s", cfg.Collector)
+	}
+}


### PR DESCRIPTION
## Summary
- use generic otlptrace exporter in `trace.Init`
- allow collector override via `AGENTRY_COLLECTOR`
- initialise OTLP exporter when collector configured
- document environment variable usage
- test config collector env override

## Testing
- `go test ./...` *(fails: Get https://storage.googleapis.com/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685a2a1b71e88320b839c8ddd3dfa7cb