### PR TITLE
Add Prometheus metrics instrumentation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -151,6 +151,10 @@ collector: localhost:4318
 
 The server then exposes `/metrics` and streams spans to the specified collector.
 
+Metrics include HTTP request counts (`agentry_http_requests_total`),
+token usage (`agentry_tokens_total`) and tool execution latency
+(`agentry_tool_latency_seconds`).
+
 ## Plugin Management
 
 Agentry includes tooling to fetch and install external plugins:

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"os"
 	"sort"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/marcodenic/agentry/internal/core"
@@ -31,12 +30,10 @@ var (
 )
 
 func instrument(path string, h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		start := time.Now()
-		h.ServeHTTP(w, r)
-		httpRequests.WithLabelValues(path).Inc()
-		httpDuration.WithLabelValues(path).Observe(time.Since(start).Seconds())
-	})
+	counter := httpRequests.MustCurryWith(prometheus.Labels{"path": path})
+	duration := httpDuration.MustCurryWith(prometheus.Labels{"path": path})
+	return promhttp.InstrumentHandlerDuration(duration,
+		promhttp.InstrumentHandlerCounter(counter, h))
 }
 
 func Handler(agents map[string]*core.Agent, metrics bool, saveID, resumeID string) http.Handler {

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -1,8 +1,10 @@
 package tests
 
 import (
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/marcodenic/agentry/internal/server"
@@ -13,6 +15,11 @@ func TestMetricsEndpoint(t *testing.T) {
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 
+	// generate some metrics
+	if _, err := http.Get(srv.URL + "/"); err != nil {
+		t.Fatal(err)
+	}
+
 	resp, err := http.Get(srv.URL + "/metrics")
 	if err != nil {
 		t.Fatal(err)
@@ -21,5 +28,13 @@ func TestMetricsEndpoint(t *testing.T) {
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "agentry_http_requests_total") {
+		t.Fatalf("metrics missing: %s", b[:100])
 	}
 }


### PR DESCRIPTION
## Summary
- instrument HTTP handlers via promhttp
- document the available Prometheus metrics
- verify `/metrics` returns data

## Testing
- `go test ./...` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a2a0e2c308320a28bbf6e40bc6a62