### PR TITLE
Audit log rotation and extended tracing

### DIFF
--- a/cmd/agentry/build.go
+++ b/cmd/agentry/build.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/marcodenic/agentry/internal/audit"
 	"github.com/marcodenic/agentry/internal/config"
 	"github.com/marcodenic/agentry/internal/core"
 	"github.com/marcodenic/agentry/internal/memory"
 	"github.com/marcodenic/agentry/internal/model"
 	"github.com/marcodenic/agentry/internal/router"
 	"github.com/marcodenic/agentry/internal/tool"
+	"github.com/marcodenic/agentry/internal/trace"
 	"github.com/marcodenic/agentry/pkg/memstore"
 )
 
@@ -29,9 +31,11 @@ func buildAgent(cfg *config.File) (*core.Agent, error) {
 		}
 		reg[m.Name] = tl
 	}
+	var logWriter *audit.Log
 	if path := os.Getenv("AGENTRY_AUDIT_LOG"); path != "" {
-		if f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644); err == nil {
-			reg = tool.WrapWithAudit(reg, f)
+		if lw, err := audit.Open(path, 1<<20); err == nil {
+			logWriter = lw
+			reg = tool.WrapWithAudit(reg, lw)
 		}
 	}
 
@@ -83,5 +87,8 @@ func buildAgent(cfg *config.File) (*core.Agent, error) {
 	}
 
 	ag := core.New(rules, reg, memory.NewInMemory(), store, vec, nil)
+	if logWriter != nil {
+		ag.Tracer = trace.NewJSONL(logWriter)
+	}
 	return ag, nil
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/marcodenic/agentry/internal/audit"
 	"github.com/marcodenic/agentry/internal/config"
 	"github.com/marcodenic/agentry/internal/core"
 	"github.com/marcodenic/agentry/internal/memory"
@@ -14,6 +15,7 @@ import (
 	"github.com/marcodenic/agentry/internal/router"
 	"github.com/marcodenic/agentry/internal/taskqueue"
 	"github.com/marcodenic/agentry/internal/tool"
+	"github.com/marcodenic/agentry/internal/trace"
 	"github.com/marcodenic/agentry/pkg/memstore"
 )
 
@@ -93,6 +95,13 @@ func buildAgent(cfg *config.File) (*core.Agent, error) {
 		}
 		reg[m.Name] = tl
 	}
+	var logWriter *audit.Log
+	if path := os.Getenv("AGENTRY_AUDIT_LOG"); path != "" {
+		if lw, err := audit.Open(path, 1<<20); err == nil {
+			logWriter = lw
+			reg = tool.WrapWithAudit(reg, lw)
+		}
+	}
 
 	clients := map[string]model.Client{}
 	for _, m := range cfg.Models {
@@ -142,5 +151,8 @@ func buildAgent(cfg *config.File) (*core.Agent, error) {
 	}
 
 	ag := core.New(rules, reg, memory.NewInMemory(), store, vec, nil)
+	if logWriter != nil {
+		ag.Tracer = trace.NewJSONL(logWriter)
+	}
 	return ag, nil
 }

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -1,0 +1,85 @@
+package audit
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// Log writes newline-delimited JSON data to a file with simple size-based rotation.
+type Log struct {
+	path    string
+	maxSize int64
+
+	mu   sync.Mutex
+	file *os.File
+	size int64
+}
+
+// Open creates or appends to the log file at path. max specifies the
+// maximum size in bytes before the file is rotated. If max is 0, no rotation
+// occurs.
+func Open(path string, max int64) (*Log, error) {
+	if path == "" {
+		return nil, fmt.Errorf("path required")
+	}
+	l := &Log{path: path, maxSize: max}
+	if err := l.open(); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+func (l *Log) open() error {
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+	l.file = f
+	fi, err := f.Stat()
+	if err == nil {
+		l.size = fi.Size()
+	}
+	return nil
+}
+
+func (l *Log) rotate() error {
+	if l.maxSize <= 0 || l.size < l.maxSize {
+		return nil
+	}
+	if l.file != nil {
+		l.file.Close()
+	}
+	ts := time.Now().UTC().Format("20060102150405")
+	newName := fmt.Sprintf("%s.%s", l.path, ts)
+	if err := os.Rename(l.path, newName); err != nil {
+		return err
+	}
+	return l.open()
+}
+
+// Write implements io.Writer.
+func (l *Log) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.rotate(); err != nil {
+		return 0, err
+	}
+	n, err := l.file.Write(p)
+	l.size += int64(n)
+	return n, err
+}
+
+// Close closes the underlying file.
+func (l *Log) Close() error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.file == nil {
+		return nil
+	}
+	return l.file.Close()
+}
+
+// Path returns the current log file path.
+func (l *Log) Path() string { return l.path }

--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -92,6 +92,7 @@ func (a *Agent) Run(ctx context.Context, input string) (string, error) {
 				return "", err
 			}
 			applyVarsMap(args, a.Vars)
+			a.Trace(ctx, trace.EventToolStart, map[string]any{"name": tc.Name, "args": args})
 			start := time.Now()
 			r, err := t.Execute(ctx, args)
 			toolLatency.WithLabelValues(a.ID.String(), tc.Name).Observe(time.Since(start).Seconds())

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -13,7 +13,9 @@ import (
 type EventType string
 
 const (
-	EventStepStart  EventType = "step_start"
+	EventStepStart EventType = "step_start"
+	// EventToolStart captures a tool invocation including parameters.
+	EventToolStart  EventType = "tool_start"
 	EventToolEnd    EventType = "tool_end"
 	EventFinal      EventType = "final"
 	EventModelStart EventType = "model_start"

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -387,7 +387,12 @@ func (m Model) startAgent(id uuid.UUID, input string) (Model, tea.Cmd) {
 
 	pr, pw := io.Pipe()
 	errCh := make(chan error, 1)
-	info.Agent.Tracer = trace.NewJSONL(pw)
+	tracer := trace.NewJSONL(pw)
+	if info.Agent.Tracer != nil {
+		info.Agent.Tracer = trace.NewMulti(info.Agent.Tracer, tracer)
+	} else {
+		info.Agent.Tracer = tracer
+	}
 	info.Scanner = bufio.NewScanner(pr)
 	ctx := context.WithValue(context.Background(), teamctx.Key{}, m.team)
 	ctx, cancel := context.WithCancel(ctx)

--- a/tests/audit_test.go
+++ b/tests/audit_test.go
@@ -3,20 +3,42 @@ package tests
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/marcodenic/agentry/internal/audit"
 	"github.com/marcodenic/agentry/internal/tool"
 )
 
 func TestAuditMiddleware(t *testing.T) {
-	reg := tool.DefaultRegistry()
-	var buf bytes.Buffer
-	reg = tool.WrapWithAudit(reg, &buf)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	logWriter, err := audit.Open(path, 1<<20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer logWriter.Close()
+
+	reg := tool.WrapWithAudit(tool.DefaultRegistry(), logWriter)
 	tl, _ := reg.Use("echo")
 	if _, err := tl.Execute(context.Background(), map[string]any{"text": "hi"}); err != nil {
 		t.Fatalf("exec: %v", err)
 	}
-	if !bytes.Contains(buf.Bytes(), []byte("\"tool\":\"echo\"")) {
-		t.Fatalf("audit log missing")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := bytes.Split(bytes.TrimSpace(data), []byte("\n"))
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 event got %d", len(parts))
+	}
+	var ev tool.AuditEvent
+	if err := json.Unmarshal(parts[0], &ev); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if ev.Tool != "echo" || ev.Args["text"] != "hi" || ev.Timestamp.IsZero() {
+		t.Fatalf("bad event: %+v", ev)
 	}
 }


### PR DESCRIPTION
## Summary
- create `internal/audit` package for size‑limited JSONL logs
- capture tool arguments via new `EventToolStart`
- send audit and trace events to `AGENTRY_AUDIT_LOG`
- keep tracer output when TUI overrides it
- test audit log entries

## Testing
- `go test ./...` *(fails: github.com/klauspost/compress download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685a29ff79fc8320abd361cecead0d63