### PR TITLE
Add policy approval interface with server integration

### DIFF
--- a/cmd/agentry/main.go
+++ b/cmd/agentry/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/marcodenic/agentry/internal/core"
 	"github.com/marcodenic/agentry/internal/env"
 	"github.com/marcodenic/agentry/internal/eval"
+	"github.com/marcodenic/agentry/internal/policy"
 	"github.com/marcodenic/agentry/internal/server"
 	"github.com/marcodenic/agentry/internal/tool"
 	"github.com/marcodenic/agentry/internal/trace"
@@ -181,7 +182,8 @@ func main() {
 		}
 		agents := map[string]*core.Agent{"default": ag}
 		fmt.Println("Serving HTTP on :8080")
-		server.Serve(agents, cfg.Metrics, *saveID, *resumeID)
+		ap := policy.Manager{Prompt: policy.CLIPrompt}
+		server.Serve(agents, cfg.Metrics, *saveID, *resumeID, ap)
 	case "eval":
 		cfg, err := config.Load(configPath)
 		if err != nil {

--- a/internal/policy/approver.go
+++ b/internal/policy/approver.go
@@ -1,0 +1,105 @@
+package policy
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/marcodenic/agentry/internal/tool"
+)
+
+// Request describes a pending tool execution to be approved.
+type Request struct {
+	AgentID string
+	Tool    string
+	Args    map[string]any
+}
+
+// Decision indicates the result of a Check.
+type Decision int
+
+const (
+	// NoOpinion means the checker neither approves nor denies.
+	NoOpinion Decision = iota
+	// Approve allows the tool execution.
+	Approve
+	// Deny rejects the tool execution.
+	Deny
+)
+
+// Checker evaluates whether a request should be approved.
+type Checker interface {
+	Check(ctx context.Context, req Request) (Decision, error)
+}
+
+// Approver decides if a request may proceed.
+type Approver interface {
+	Approve(ctx context.Context, req Request) (bool, error)
+}
+
+// PromptFunc requests manual approval from a user.
+type PromptFunc func(req Request) bool
+
+// Manager runs one or more checks and optionally prompts the user.
+type Manager struct {
+	Checks []Checker
+	Prompt PromptFunc
+}
+
+func (m Manager) Approve(ctx context.Context, req Request) (bool, error) {
+	for _, c := range m.Checks {
+		d, err := c.Check(ctx, req)
+		if err != nil {
+			return false, err
+		}
+		switch d {
+		case Approve:
+			return true, nil
+		case Deny:
+			return false, nil
+		}
+	}
+	if m.Prompt != nil {
+		return m.Prompt(req), nil
+	}
+	return false, nil
+}
+
+// CLIPrompt prompts on stdin when manual approval is required.
+func CLIPrompt(req Request) bool {
+	fmt.Printf("approve tool %s with args %#v? [y/N]: ", req.Tool, req.Args)
+	rd := bufio.NewReader(os.Stdin)
+	line, _ := rd.ReadString('\n')
+	line = strings.TrimSpace(strings.ToLower(line))
+	return line == "y" || line == "yes"
+}
+
+// WrapTools wraps a registry with approval checks.
+func WrapTools(reg tool.Registry, ap Approver) tool.Registry {
+	if ap == nil {
+		return reg
+	}
+	out := tool.Registry{}
+	for name, t := range reg {
+		out[name] = approvalTool{Tool: t, ap: ap}
+	}
+	return out
+}
+
+type approvalTool struct {
+	tool.Tool
+	ap Approver
+}
+
+func (a approvalTool) Execute(ctx context.Context, args map[string]any) (string, error) {
+	ok, err := a.ap.Approve(ctx, Request{Tool: a.Name(), Args: args})
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("tool %s not approved", a.Name())
+	}
+	return a.Tool.Execute(ctx, args)
+}

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMetricsEndpoint(t *testing.T) {
-	h := server.Handler(nil, true, "", "")
+	h := server.Handler(nil, true, "", "", nil)
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 

--- a/tests/policy_test.go
+++ b/tests/policy_test.go
@@ -1,0 +1,63 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/policy"
+	"github.com/marcodenic/agentry/internal/tool"
+)
+
+type allowCheck struct{}
+
+func (allowCheck) Check(ctx context.Context, req policy.Request) (policy.Decision, error) {
+	return policy.Approve, nil
+}
+
+type denyCheck struct{}
+
+func (denyCheck) Check(ctx context.Context, req policy.Request) (policy.Decision, error) {
+	return policy.Deny, nil
+}
+
+func TestPolicyAutoApprove(t *testing.T) {
+	cnt := 0
+	reg := tool.Registry{"t": tool.New("t", "", func(context.Context, map[string]any) (string, error) { cnt++; return "ok", nil })}
+	ap := policy.Manager{Checks: []policy.Checker{allowCheck{}}}
+	reg = policy.WrapTools(reg, ap)
+	tl, _ := reg.Use("t")
+	if _, err := tl.Execute(context.Background(), nil); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if cnt != 1 {
+		t.Fatalf("tool not executed")
+	}
+}
+
+func TestPolicyPrompt(t *testing.T) {
+	cnt := 0
+	reg := tool.Registry{"t": tool.New("t", "", func(context.Context, map[string]any) (string, error) { cnt++; return "ok", nil })}
+	called := false
+	ap := policy.Manager{Prompt: func(req policy.Request) bool { called = true; return true }}
+	reg = policy.WrapTools(reg, ap)
+	tl, _ := reg.Use("t")
+	if _, err := tl.Execute(context.Background(), nil); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if !called {
+		t.Fatalf("prompt not called")
+	}
+	if cnt != 1 {
+		t.Fatalf("tool not executed")
+	}
+}
+
+func TestPolicyDeny(t *testing.T) {
+	reg := tool.Registry{"t": tool.New("t", "", func(context.Context, map[string]any) (string, error) { return "ok", nil })}
+	ap := policy.Manager{Checks: []policy.Checker{denyCheck{}}}
+	reg = policy.WrapTools(reg, ap)
+	tl, _ := reg.Use("t")
+	if _, err := tl.Execute(context.Background(), nil); err == nil {
+		t.Fatalf("expected denial")
+	}
+}

--- a/tests/server_concurrent_test.go
+++ b/tests/server_concurrent_test.go
@@ -17,7 +17,7 @@ func TestServerConcurrentInvoke(t *testing.T) {
 	ag := newAgent("ok", nil)
 	agents := map[string]*core.Agent{"a": ag}
 
-	srv := httptest.NewServer(server.Handler(agents, false, "", ""))
+	srv := httptest.NewServer(server.Handler(agents, false, "", "", nil))
 	defer srv.Close()
 
 	const n = 10

--- a/tests/server_spawn_kill_test.go
+++ b/tests/server_spawn_kill_test.go
@@ -25,7 +25,7 @@ func TestServerSpawnKill(t *testing.T) {
 	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	agents := map[string]*core.Agent{"default": ag}
 
-	srv := httptest.NewServer(server.Handler(agents, false, "", ""))
+	srv := httptest.NewServer(server.Handler(agents, false, "", "", nil))
 	defer srv.Close()
 
 	// spawn a new agent


### PR DESCRIPTION
## Summary
- implement approval manager and CLI prompt
- wrap tool registry with approval checks
- integrate approver into HTTP server and CLI
- update existing server tests for new signature
- test approval logic in `policy_test.go`

## Testing
- `go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685a29e3a1b08320ad3481ec067619ad