### PR TITLE
Add flow and team builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,12 @@ tools:
   - name: patch # 🩹 apply a unified diff
     type: builtin
   - name: sourcegraph # 🔍 search public repositories
-    type: builtin  - name: agent # 🤖 delegate tasks to another agent
+    type: builtin
+  - name: agent # 🤖 delegate tasks to another agent
+    type: builtin
+  - name: flow # 🗺️ run a flow file
+    type: builtin
+  - name: team # 👥 run a multi-agent chat
     type: builtin
   - name: mcp # 🎮 connect to MCP servers
     type: builtin

--- a/tests/flow_tool_test.go
+++ b/tests/flow_tool_test.go
@@ -1,0 +1,34 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/tool"
+)
+
+func TestFlowBuiltin(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `agents:
+  tester:
+    model: mock
+tasks:
+  - agent: tester
+    input: hi`
+	if err := os.WriteFile(filepath.Join(dir, ".agentry.flow.yaml"), []byte(yaml), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tl, ok := tool.DefaultRegistry().Use("flow")
+	if !ok {
+		t.Fatal("flow tool missing")
+	}
+	out, err := tl.Execute(context.Background(), map[string]any{"path": dir})
+	if err != nil {
+		t.Fatalf("exec failed: %v", err)
+	}
+	if out != "hello" {
+		t.Fatalf("unexpected output %s", out)
+	}
+}

--- a/tests/team_tool_test.go
+++ b/tests/team_tool_test.go
@@ -1,0 +1,23 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/tool"
+)
+
+func TestTeamBuiltin(t *testing.T) {
+	tl, ok := tool.DefaultRegistry().Use("team")
+	if !ok {
+		t.Fatal("team tool missing")
+	}
+	out, err := tl.Execute(context.Background(), map[string]any{"n": 2, "topic": "hi"})
+	if err != nil {
+		t.Fatalf("exec failed: %v", err)
+	}
+	if lines := strings.Split(strings.TrimSpace(out), "\n"); len(lines) == 0 {
+		t.Fatal("no output")
+	}
+}


### PR DESCRIPTION
## Summary
- allow running flows and multi-agent chats via new builtin tools
- document the new tools in README
- test the flow and team builtins

## Testing
- `go test ./...` *(fails: import cycle / network restrictions)*
- `cd ts-sdk && npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a269e0e548320af0707cc79efbf99