### PR TITLE
Add agent dashboard visuals

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -478,7 +478,7 @@ Agentry aims to become a best-in-class platform for multi-agent AI by anticipati
 | 9.4 | VS Code extension           | Editor integration | SSE panel           |  7.1 | ✅
 | 9.5 | Multi-agent TUI redesign    | Usability          | See TUI_IMPLEMENTATION_PLAN.md |  —  |
 | 9.6 | TUI command system          | Control agents     | /spawn /stop /switch commands   | 9.5 | ✅ |
-| 9.7 | Real-time agent dashboard   | Visual status      | spinners + token bars | 9.5 |
+| 9.7 | Real-time agent dashboard   | Visual status      | spinners + token bars (in progress) | 9.5 |
 | 9.8 | Custom theming              | Brand look         | lipgloss styles & presets | 9.5 |
 
 ## ❿ Documentation & Examples (docs)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,6 +72,10 @@ Create a `theme.json` file to customise colours and keyboard shortcuts. Agentry 
 {
   "userBarColor": "#00FF00",
   "aiBarColor": "#FF00FF",
+  "idleColor": "#22C55E",
+  "runningColor": "#FBBF24",
+  "errorColor": "#EF4444",
+  "stoppedColor": "#6B7280",
   "keybinds": {
     "quit": "ctrl+c",
     "toggleTab": "tab",

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -26,11 +26,17 @@ type Palette struct {
 // Theme holds colour settings and keybinds.
 // Mode selects which built-in palette to use ("light" or "dark").
 type Theme struct {
-	Mode         string   `json:"mode"`
-	Palette      Palette  `json:"palette"`
-	UserBarColor string   `json:"userBarColor"`
-	AIBarColor   string   `json:"aiBarColor"`
-	Keybinds     Keybinds `json:"keybinds"`
+	Mode         string  `json:"mode"`
+	Palette      Palette `json:"palette"`
+	UserBarColor string  `json:"userBarColor"`
+	AIBarColor   string  `json:"aiBarColor"`
+
+	IdleColor    string `json:"idleColor"`
+	RunningColor string `json:"runningColor"`
+	ErrorColor   string `json:"errorColor"`
+	StoppedColor string `json:"stoppedColor"`
+
+	Keybinds Keybinds `json:"keybinds"`
 }
 
 // Pre-defined palettes for light and dark modes.
@@ -46,6 +52,10 @@ func DefaultTheme() Theme {
 		Palette:      DarkPalette,
 		UserBarColor: "#8B5CF6",
 		AIBarColor:   "#9CA3AF",
+		IdleColor:    "#22C55E",
+		RunningColor: "#FBBF24",
+		ErrorColor:   "#EF4444",
+		StoppedColor: "#6B7280",
 		Keybinds: Keybinds{
 			Quit:      "ctrl+c",
 			ToggleTab: "tab",


### PR DESCRIPTION
## Summary
- extend theme with status colours
- show status dots, spinner and token bar in agent panel
- style new agents on spawn
- document theme fields
- note real-time dashboard progress in ROADMAP

## Testing
- `go test ./...` *(fails: forbidden download)*
- `cd ts-sdk && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a427ced30832096630f0cff3b5982