### PR TITLE
Remove dead vector API in memstore

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -514,5 +514,12 @@ Agentry aims to become a best-in-class platform for multi-agent AI by anticipati
 
 ---
 
-> **Mantra:** _Keep the core fast and tiny; everything else is optional & pluggable._  
+### Changelog
+
+- 2025‑06‑24 – Removed unused vector interface from `pkg/memstore` to simplify
+  the codebase.
+
+---
+
+> **Mantra:** _Keep the core fast and tiny; everything else is optional & pluggable._
 > End of machine‑readable backlog.

--- a/pkg/memstore/file.go
+++ b/pkg/memstore/file.go
@@ -10,33 +10,27 @@ import (
 
 // File is a simple JSON-backed store persisted to disk.
 type File struct {
-	path   string
-	mu     sync.RWMutex
-	kv     map[string]map[string][]byte
-	meta   map[string]map[string]int64
-	vector map[string]string
+	path string
+	mu   sync.RWMutex
+	kv   map[string]map[string][]byte
+	meta map[string]map[string]int64
 }
 
 func NewFile(path string) (*File, error) {
 	f := &File{
-		path:   path,
-		kv:     map[string]map[string][]byte{},
-		meta:   map[string]map[string]int64{},
-		vector: map[string]string{},
+		path: path,
+		kv:   map[string]map[string][]byte{},
+		meta: map[string]map[string]int64{},
 	}
 	if b, err := os.ReadFile(path); err == nil {
 		var data struct {
-			KV     map[string]map[string][]byte `json:"kv"`
-			Meta   map[string]map[string]int64  `json:"meta"`
-			Vector map[string]string            `json:"vector"`
+			KV   map[string]map[string][]byte `json:"kv"`
+			Meta map[string]map[string]int64  `json:"meta"`
 		}
 		if err := json.Unmarshal(b, &data); err == nil && data.KV != nil {
 			f.kv = data.KV
 			if data.Meta != nil {
 				f.meta = data.Meta
-			}
-			if data.Vector != nil {
-				f.vector = data.Vector
 			}
 		} else {
 			// legacy format: just kv map
@@ -50,10 +44,9 @@ func NewFile(path string) (*File, error) {
 
 func (f *File) persist() error {
 	data := struct {
-		KV     map[string]map[string][]byte `json:"kv"`
-		Meta   map[string]map[string]int64  `json:"meta"`
-		Vector map[string]string            `json:"vector"`
-	}{f.kv, f.meta, f.vector}
+		KV   map[string]map[string][]byte `json:"kv"`
+		Meta map[string]map[string]int64  `json:"meta"`
+	}{f.kv, f.meta}
 	b, err := json.Marshal(data)
 	if err != nil {
 		return err
@@ -90,26 +83,6 @@ func (f *File) Get(_ context.Context, bucket, key string) ([]byte, error) {
 	cp := make([]byte, len(val))
 	copy(cp, val)
 	return cp, nil
-}
-
-func (f *File) Add(_ context.Context, id, text string) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.vector[id] = text
-	return f.persist()
-}
-
-func (f *File) Query(_ context.Context, _ string, k int) ([]string, error) {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-	ids := make([]string, 0, k)
-	for id := range f.vector {
-		ids = append(ids, id)
-		if len(ids) >= k {
-			break
-		}
-	}
-	return ids, nil
 }
 
 func (f *File) Cleanup(_ context.Context, bucket string, ttl time.Duration) error {

--- a/pkg/memstore/inmem.go
+++ b/pkg/memstore/inmem.go
@@ -8,17 +8,15 @@ import (
 
 // InMemory is a simple ephemeral store backed by Go maps.
 type InMemory struct {
-	mu     sync.RWMutex
-	kv     map[string]map[string][]byte
-	meta   map[string]map[string]int64
-	vector map[string]string
+	mu   sync.RWMutex
+	kv   map[string]map[string][]byte
+	meta map[string]map[string]int64
 }
 
 func NewInMemory() *InMemory {
 	return &InMemory{
-		kv:     map[string]map[string][]byte{},
-		meta:   map[string]map[string]int64{},
-		vector: map[string]string{},
+		kv:   map[string]map[string][]byte{},
+		meta: map[string]map[string]int64{},
 	}
 }
 
@@ -51,26 +49,6 @@ func (m *InMemory) Get(_ context.Context, bucket, key string) ([]byte, error) {
 	cp := make([]byte, len(val))
 	copy(cp, val)
 	return cp, nil
-}
-
-func (m *InMemory) Add(_ context.Context, id, text string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.vector[id] = text
-	return nil
-}
-
-func (m *InMemory) Query(_ context.Context, _ string, k int) ([]string, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	ids := make([]string, 0, k)
-	for id := range m.vector {
-		ids = append(ids, id)
-		if len(ids) >= k {
-			break
-		}
-	}
-	return ids, nil
 }
 
 func (m *InMemory) Cleanup(_ context.Context, bucket string, ttl time.Duration) error {

--- a/pkg/memstore/memstore.go
+++ b/pkg/memstore/memstore.go
@@ -11,12 +11,6 @@ type KV interface {
 	Get(ctx context.Context, bucket, key string) ([]byte, error)
 }
 
-// Vector defines storage for text documents retrievable via similarity.
-type Vector interface {
-	Add(ctx context.Context, id, text string) error
-	Query(ctx context.Context, text string, k int) ([]string, error)
-}
-
 // Cleaner defines optional TTL-based cleanup for a store.
 type Cleaner interface {
 	Cleanup(ctx context.Context, bucket string, ttl time.Duration) error

--- a/pkg/memstore/sqlite.go
+++ b/pkg/memstore/sqlite.go
@@ -24,9 +24,6 @@ func NewSQLite(path string) (*SQLite, error) {
 	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS kv_meta (bucket TEXT, key TEXT, updated INTEGER, PRIMARY KEY(bucket,key))`); err != nil {
 		return nil, err
 	}
-	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS vector (id TEXT PRIMARY KEY, text TEXT)`); err != nil {
-		return nil, err
-	}
 	return &SQLite{db: db}, nil
 }
 
@@ -58,28 +55,6 @@ func (s *SQLite) Get(ctx context.Context, bucket, key string) ([]byte, error) {
 		return nil, err
 	}
 	return val, nil
-}
-
-func (s *SQLite) Add(ctx context.Context, id, text string) error {
-	_, err := s.db.ExecContext(ctx, `INSERT OR REPLACE INTO vector(id,text) VALUES(?,?)`, id, text)
-	return err
-}
-
-func (s *SQLite) Query(ctx context.Context, text string, k int) ([]string, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id FROM vector LIMIT ?`, k)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	ids := []string{}
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		ids = append(ids, id)
-	}
-	return ids, rows.Err()
 }
 
 // Cleanup removes entries older than the provided TTL from the given bucket.


### PR DESCRIPTION
## Summary
- drop unused `Vector` interface from memstore
- clean up memstore implementations
- document change in `ROADMAP.md`

## Testing
- `go test ./pkg/...`
- `npm test` in `ts-sdk`


------
https://chatgpt.com/codex/tasks/task_e_685a40e0342483208a29b1e8339ae46b