### PR TITLE
feat(core): configurable limits and http port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
         with:
           go-version: "1.23"
 
+      - name: Check gofmt
+        run: |
+          diff=$(gofmt -l $(git ls-files '*.go'))
+          if [ -n "$diff" ]; then echo "gofmt needed:" && echo "$diff" && exit 1; fi
+
+      - name: Run go vet
+        run: go vet ./...
+
       - name: Install and run golangci-lint
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ You can now use subcommands instead of the --mode flag:
 - `agentry flow` (run `.agentry.flow.yaml`)
 - `agentry version` (show version)
 
+Server port can be overridden with `--port` or `AGENTRY_PORT`. Adjust the agent
+iteration limit using `--max-iter` or `max_iterations` in the config file.
+
 Example:
 
 ```bash

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -402,6 +402,7 @@ Agentry aims to become a best-in-class platform for multi-agent AI by anticipati
 | 1.3 | Checkpoint API (`Checkpoint()/Resume()`)   | Pause/continue   | Serialize loop state JSON after each event |  1.1 | ✅
 | 1.4 | Max‑iteration graceful yield               | Avoid hard cap   | Emit `EventYield` when limit reached       |  1.3 | ✅
 | 1.5 | ~~Session GC daemon~~                          | Disk hygiene     | TTL sweep & compaction                     |  1.1 | ✅
+| 1.6 | Configurable iteration limit               | Tune workloads    | CLI flag & config field                    |  1.4 | ✅
 
 ## ❷ Sandboxing & Security (security)
 

--- a/cmd/agentry/build.go
+++ b/cmd/agentry/build.go
@@ -94,5 +94,8 @@ func buildAgent(cfg *config.File) (*core.Agent, error) {
 	if logWriter != nil {
 		ag.Tracer = trace.NewJSONL(logWriter)
 	}
+	if cfg.MaxIterations > 0 {
+		ag.MaxIterations = cfg.MaxIterations
+	}
 	return ag, nil
 }

--- a/cmd/agentry/plugin.go
+++ b/cmd/agentry/plugin.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -27,7 +28,7 @@ func runPluginCmd(args []string) {
 			fmt.Println("Usage: agentry plugin fetch <index> <name>")
 			os.Exit(1)
 		}
-		if _, err := plugin.Fetch(args[1], args[2]); err != nil {
+		if _, err := plugin.Fetch(context.Background(), args[1], args[2]); err != nil {
 			fmt.Printf("fetch failed: %v\n", err)
 			os.Exit(1)
 		}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -155,5 +155,8 @@ func buildAgent(cfg *config.File) (*core.Agent, error) {
 	if logWriter != nil {
 		ag.Tracer = trace.NewJSONL(logWriter)
 	}
+	if cfg.MaxIterations > 0 {
+		ag.MaxIterations = cfg.MaxIterations
+	}
 	return ag, nil
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -22,6 +22,9 @@ You can now use subcommands instead of the --mode flag:
 - `agentry eval` (evaluation)
 - `agentry flow` (run `.agentry.flow.yaml`)
 
+Use `--port 9090` or set `AGENTRY_PORT` to change the HTTP server port. Set
+`--max-iter` or `max_iterations:` in `.agentry.yaml` to control the iteration limit.
+
 Example:
 
 ```bash

--- a/internal/converse/runner.go
+++ b/internal/converse/runner.go
@@ -91,7 +91,11 @@ func runAgent(ctx context.Context, ag *core.Agent, input, name string, peers []s
 	client, _ := ag.Route.Select(input)
 	msgs := core.BuildMessages(ag.Prompt, ag.Vars, ag.Mem.History(), input)
 	specs := tool.BuildSpecs(ag.Tools)
-	for i := 0; i < 8; i++ {
+	limit := ag.MaxIterations
+	if limit <= 0 {
+		limit = 8
+	}
+	for i := 0; i < limit; i++ {
 		res, err := client.Complete(ctx, msgs, specs)
 		if err != nil {
 			return "", err

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 
@@ -8,16 +9,28 @@ import (
 )
 
 // Load loads variables from .env.local if the file exists.
-func Load() {
+// Load searches for filename (default ".env.local") upward and loads variables.
+func Load(filename ...string) {
+	name := ".env.local"
+	if len(filename) > 0 && filename[0] != "" {
+		name = filename[0]
+	} else if env := os.Getenv("AGENTRY_ENV_FILE"); env != "" {
+		name = env
+	}
 	dir, err := os.Getwd()
 	if err != nil {
+		log.Printf("env load: %v", err)
 		return
 	}
 	for {
-		path := filepath.Join(dir, ".env.local")
+		path := filepath.Join(dir, name)
 		if _, err := os.Stat(path); err == nil {
-			_ = godotenv.Load(path)
+			if err := godotenv.Load(path); err != nil {
+				log.Printf("env load: %v", err)
+			}
 			break
+		} else if !os.IsNotExist(err) {
+			log.Printf("env stat: %v", err)
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {

--- a/internal/memory/vector.go
+++ b/internal/memory/vector.go
@@ -1,6 +1,11 @@
 package memory
 
-import "context"
+import (
+	"context"
+	"math"
+	"sort"
+	"strings"
+)
 
 // VectorStore defines minimal interface for vector retrieval.
 type VectorStore interface {
@@ -13,25 +18,59 @@ type VectorStore interface {
 // InMemoryVector is a naive store keeping text docs.
 type InMemoryVector struct {
 	docs map[string]string
+	vecs map[string]map[string]float64
 }
 
 func NewInMemoryVector() *InMemoryVector {
-	return &InMemoryVector{docs: make(map[string]string)}
+	return &InMemoryVector{docs: make(map[string]string), vecs: make(map[string]map[string]float64)}
 }
 
 func (v *InMemoryVector) Add(_ context.Context, id, text string) error {
 	v.docs[id] = text
+	v.vecs[id] = embed(text)
 	return nil
 }
 
 func (v *InMemoryVector) Query(_ context.Context, text string, k int) ([]string, error) {
-	// Return first k IDs for now.
+	qv := embed(text)
+	type pair struct {
+		id  string
+		sim float64
+	}
+	list := make([]pair, 0, len(v.vecs))
+	for id, vec := range v.vecs {
+		list = append(list, pair{id: id, sim: cosine(vec, qv)})
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].sim > list[j].sim })
+	if k > len(list) {
+		k = len(list)
+	}
 	res := make([]string, 0, k)
-	for id := range v.docs {
-		res = append(res, id)
-		if len(res) >= k {
-			break
-		}
+	for i := 0; i < k; i++ {
+		res = append(res, list[i].id)
 	}
 	return res, nil
+}
+
+func embed(text string) map[string]float64 {
+	vec := map[string]float64{}
+	for _, w := range strings.Fields(strings.ToLower(text)) {
+		vec[w]++
+	}
+	return vec
+}
+
+func cosine(a, b map[string]float64) float64 {
+	var dot, normA, normB float64
+	for k, av := range a {
+		dot += av * b[k]
+		normA += av * av
+	}
+	for _, bv := range b {
+		normB += bv * bv
+	}
+	if normA == 0 || normB == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
 }

--- a/tests/inmemory_vector_test.go
+++ b/tests/inmemory_vector_test.go
@@ -1,0 +1,21 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/memory"
+)
+
+func TestInMemoryVectorSimilarity(t *testing.T) {
+	v := memory.NewInMemoryVector()
+	v.Add(context.Background(), "a", "hello world")
+	v.Add(context.Background(), "b", "goodbye moon")
+	ids, err := v.Query(context.Background(), "hello", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 1 || ids[0] != "a" {
+		t.Fatalf("expected a, got %#v", ids)
+	}
+}

--- a/tests/plugin_fetch_test.go
+++ b/tests/plugin_fetch_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -50,7 +51,7 @@ func TestFetchVerifiesChecksum(t *testing.T) {
 	os.Setenv("AGENTRY_REGISTRY_GPG_KEYRING", pubPath)
 	defer os.Unsetenv("AGENTRY_REGISTRY_GPG_KEYRING")
 
-	out, err := plugin.Fetch(idxPath, "p")
+	out, err := plugin.Fetch(context.Background(), idxPath, "p")
 	if err != nil {
 		t.Fatalf("fetch: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add `max_iterations` and `port` to config
- honour `--max-iter` and `--port` flags in CLI
- propagate NATS errors and allow custom server port
- improve env loader with logging and filename option
- add timeout-aware plugin fetch
- implement cosine similarity in `InMemoryVector`
- add tests for plugin fetch and vector store
- document new flags
- enforce gofmt and go vet in CI

## Testing
- `go test ./...` *(fails: access to storage.googleapis.com blocked)*
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a46842fcc8320b4deb9476310afa5