### PR TITLE
Implement cost analyzer CLI

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -456,7 +456,7 @@ Agentry aims to become a best-in-class platform for multi-agent AI by anticipati
 | 7.1 | OTLP trace exporter | Aggregate | Convert events → spans |  4.4 | ✅
 | 7.2 | Prometheus metrics  | Ops       | `/metrics` endpoint    |  4.4 | ✅
 | 7.3 | Web dashboard       | Visualize | Next.js or SvelteKit   |  7.1 | ✅
-| 7.4 | Cost estimator      | Budget    | Post‑run analyzer      |  7.2 |
+| 7.4 | Cost estimator      | Budget    | Post‑run analyzer      |  7.2 | ✅
 | 7.5 | Profiling dashboard | Perf tune | pprof + flamegraphs    |  7.2 |
 
 ## ❽ Automated Test & CI (qa)

--- a/cmd/agentry/cost.go
+++ b/cmd/agentry/cost.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/marcodenic/agentry/internal/trace"
+)
+
+func runCostCmd(args []string) {
+	fs := flag.NewFlagSet("cost", flag.ExitOnError)
+	input := fs.String("input", "", "original user prompt")
+	_ = fs.Parse(args)
+
+	var r io.Reader
+	if fs.NArg() == 0 || fs.Arg(0) == "-" {
+		r = os.Stdin
+	} else {
+		f, err := os.Open(fs.Arg(0))
+		if err != nil {
+			fmt.Printf("open log: %v\n", err)
+			os.Exit(1)
+		}
+		defer f.Close()
+		r = f
+	}
+
+	events, err := trace.ParseLog(r)
+	if err != nil {
+		fmt.Printf("parse log: %v\n", err)
+		os.Exit(1)
+	}
+	sum := trace.Analyze(*input, events)
+	fmt.Printf("tokens: %d cost: $%.4f\n", sum.Tokens, sum.Cost)
+}

--- a/cmd/agentry/main.go
+++ b/cmd/agentry/main.go
@@ -33,7 +33,7 @@ import (
 func main() {
 	env.Load()
 	if len(os.Args) < 2 {
-		fmt.Println("Usage: agentry [dev|serve|tui|eval|flow|version] [--config path/to/config.yaml]")
+		fmt.Println("Usage: agentry [dev|serve|tui|eval|flow|cost|version] [--config path/to/config.yaml]")
 		os.Exit(1)
 	}
 
@@ -329,6 +329,8 @@ func main() {
 		if *saveID != "" {
 			_ = ag.SaveState(context.Background(), *saveID)
 		}
+	case "cost":
+		runCostCmd(args)
 	case "plugin":
 		runPluginCmd(args)
 	case "tool":
@@ -336,7 +338,7 @@ func main() {
 	case "version":
 		fmt.Printf("agentry %s\n", agentry.Version)
 	default:
-		fmt.Println("unknown command. Usage: agentry [dev|serve|tui|eval|flow|version] [--config path/to/config.yaml]")
+		fmt.Println("unknown command. Usage: agentry [dev|serve|tui|eval|flow|cost|version] [--config path/to/config.yaml]")
 		os.Exit(1)
 	}
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,6 +21,7 @@ You can now use subcommands instead of the --mode flag:
 - `agentry tui` (TUI interface)
 - `agentry eval` (evaluation)
 - `agentry flow` (run `.agentry.flow.yaml`)
+- `agentry cost` (summarize trace logs)
 
 Example:
 
@@ -175,6 +176,17 @@ The server then exposes `/metrics` and streams spans to the specified collector.
 Metrics include HTTP request counts (`agentry_http_requests_total`),
 token usage (`agentry_tokens_total`) and tool execution latency
 (`agentry_tool_latency_seconds`).
+
+### Cost Analysis
+
+Use `agentry cost` to summarize token usage and estimated cost from a
+JSONL trace log:
+
+```bash
+agentry cost --input "original prompt" trace.jsonl
+```
+
+The command prints the total tokens processed and approximate dollar cost.
 
 ## Plugin Management
 


### PR DESCRIPTION
## Summary
- add `agentry cost` command to summarize trace logs
- document new command in usage guide
- mark cost estimator item as complete in ROADMAP

## Testing
- `go test ./...` *(fails: forbidden storage.googleapis.com access)*
- `cd ts-sdk && npm install && npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a46eedf3083208d8d3da9ba6375c4