### PR TITLE
Improve trace analyzer docs and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ Agentry is a minimal, extensible agentic runtime written in Go, with a TypeScrip
 | ------- | ------------------------- | ------------------- | ---------------------------- |
 | agentry | Main agent runtime        | cmd/agentry/main.go | `go run cmd/agentry/main.go` |
 | ts-sdk  | TypeScript SDK entrypoint | ts-sdk/src/index.ts | `cd ts-sdk && npm run build` |
+| trace analyzer | Token usage summary tool | cmd/agentry/main.go analyze | `agentry analyze trace.jsonl` |
 
 ---
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @marcodenic

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can now use subcommands instead of the --mode flag:
 - `agentry tui` (TUI interface)
 - `agentry eval` (evaluation)
 - `agentry flow` (run `.agentry.flow.yaml`)
+- `agentry analyze trace.log` (token/cost summary)
 - `agentry version` (show version)
 
 Example:
@@ -99,6 +100,12 @@ Run the sample scenarios in `examples/flows`:
 agentry flow examples/flows/research_task
 agentry flow examples/flows/etl_pipeline
 agentry flow examples/flows/multi_agent_chat
+```
+
+After running a flow with `AGENTRY_TRACE_FILE` set, generate a token usage summary:
+
+```bash
+agentry analyze path/to/trace.jsonl
 ```
 
 More advanced scenarios are available in the [agentry-demos](./agentry-demos) repository:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -456,8 +456,9 @@ Agentry aims to become a best-in-class platform for multi-agent AI by anticipati
 | 7.1 | OTLP trace exporter | Aggregate | Convert events → spans |  4.4 | ✅
 | 7.2 | Prometheus metrics  | Ops       | `/metrics` endpoint    |  4.4 | ✅
 | 7.3 | Web dashboard       | Visualize | Next.js or SvelteKit   |  7.1 | ✅
-| 7.4 | Cost estimator      | Budget    | Post‑run analyzer      |  7.2 |
-| 7.5 | Profiling dashboard | Perf tune | pprof + flamegraphs    |  7.2 |
+| 7.4 | Cost estimator      | Budget    | Post‑run analyzer      |  7.2 | ✅
+| 7.5 | Profiling dashboard | Perf tune | pprof + flamegraphs    |  7.2 | ✅
+| 7.5a | pprof web viewer    | Quick inspect | `go tool pprof -http` cmd | 7.5 |
 
 ## ❽ Automated Test & CI (qa)
 
@@ -477,9 +478,12 @@ Agentry aims to become a best-in-class platform for multi-agent AI by anticipati
 | 9.3 | Helm chart                  | Enterprise         | k8s templates       |  4.4 | ✅
 | 9.4 | VS Code extension           | Editor integration | SSE panel           |  7.1 | ✅
 | 9.5 | Multi-agent TUI redesign    | Usability          | See TUI_IMPLEMENTATION_PLAN.md |  —  |
+| 9.5a | Layout engine refactor     | Flexible panes     | extract grid manager | 9.5 |
 | 9.6 | TUI command system          | Control agents     | /spawn /stop /switch commands   | 9.5 | ✅ |
 | 9.7 | Real-time agent dashboard   | Visual status      | spinners + token bars (in progress) | 9.5 |
+| 9.7a | WebSocket updates          | Live metrics       | push events to UI    | 9.7 |
 | 9.8 | Custom theming              | Brand look         | lipgloss styles & presets | 9.5 |
+| 9.8a | Theme config file          | User presets       | JSON theme loader    | 9.8 |
 
 ## ❿ Documentation & Examples (docs)
 
@@ -488,21 +492,26 @@ Agentry aims to become a best-in-class platform for multi-agent AI by anticipati
 | 10.1 | User guide rewrite | Up‑to‑date docs | mkdocs site                | All           | ✅
 | 10.2 | ~~“Power demos” repo~~ | Marketing       | DevOps flow, ETL, research |  Sections 3‑5 |
 | 10.3 | Tutorial videos    | Onboarding      | Asciinema + Loom           |  9.1          |
+| 10.3a | Video storyboard   | Plan content    | draft script + scenes | 10.3 |
 
 ## ⓫ Governance (meta)
 
 | ID   |  ‑ [ ] Task              | Why           | How            |
 | ---- | ------------------------ | ------------- | -------------- |
-| 11.1 | CODEOWNERS + RFC process | PR discipline | Add files      |
+| 11.1 | CODEOWNERS + RFC process | PR discipline | Add files      | ✅
 | 11.2 | Monthly roadmap call     | Feedback loop | Zoom + minutes |
+| 11.2a | Schedule GitHub event    | Community sync | recurring issue | 11.2 |
 | 11.3 | Contributor CLA          | Legal         | CLA‑assistant  |
+| 11.3a | Enable CLA bot          | PR gating     | GitHub app setup | 11.3 |
 
 ## ⓬ Performance & Benchmarking (perf)
 
 | ID   |  ‑ [ ] Task              | Why            | How                        | Deps |
 | ---- | ------------------------ | -------------- | -------------------------- | ---- |
 | 12.1 | Go vs Python micro‑bench | Speed story    | Compare throughput         |  8.4 |
+| 12.1a | Benchmark harness        | Reproduce tests | go vs py driver | 12.1 |
 | 12.2 | 1k‑agent scale test      | Validate scale | k8s job, record tokens/sec |  4.4 |
+| 12.2a | k8s cluster setup        | Provision infra | terraform module | 12.2 |
 
 ---
 

--- a/cmd/agentry/main.go
+++ b/cmd/agentry/main.go
@@ -33,7 +33,7 @@ import (
 func main() {
 	env.Load()
 	if len(os.Args) < 2 {
-		fmt.Println("Usage: agentry [dev|serve|tui|eval|flow|version] [--config path/to/config.yaml]")
+		fmt.Println("Usage: agentry [dev|serve|tui|eval|flow|analyze|version] [--config path/to/config.yaml]")
 		os.Exit(1)
 	}
 
@@ -333,10 +333,21 @@ func main() {
 		runPluginCmd(args)
 	case "tool":
 		runToolCmd(args)
+	case "analyze":
+		if len(args) < 1 {
+			fmt.Println("usage: agentry analyze trace.log")
+			return
+		}
+		sum, err := trace.AnalyzeFile(args[0])
+		if err != nil {
+			fmt.Println("analyze error:", err)
+			os.Exit(1)
+		}
+		fmt.Printf("tokens: %d cost: $%.4f\n", sum.Tokens, sum.Cost)
 	case "version":
 		fmt.Printf("agentry %s\n", agentry.Version)
 	default:
-		fmt.Println("unknown command. Usage: agentry [dev|serve|tui|eval|flow|version] [--config path/to/config.yaml]")
+		fmt.Println("unknown command. Usage: agentry [dev|serve|tui|eval|flow|analyze|version] [--config path/to/config.yaml]")
 		os.Exit(1)
 	}
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -21,6 +21,7 @@ You can now use subcommands instead of the --mode flag:
 - `agentry tui` (TUI interface)
 - `agentry eval` (evaluation)
 - `agentry flow` (run `.agentry.flow.yaml`)
+- `agentry analyze trace.log` (token/cost summary)
 
 Example:
 
@@ -193,3 +194,11 @@ export AGENTRY_REGISTRY_GPG_KEYRING=docs/registry/registry.pub
 ```
 
 Create new tools with `agentry tool init <name>`. Downloaded plugins are verified against the registry's signature before installation.
+
+## Trace Log Analysis
+
+If tracing is enabled via `AGENTRY_TRACE_FILE`, analyze the resulting log after a run:
+
+```bash
+agentry analyze path/to/trace.jsonl
+```

--- a/internal/trace/analyze.go
+++ b/internal/trace/analyze.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/marcodenic/agentry/internal/model"
@@ -63,4 +64,19 @@ func ParseLog(r io.Reader) ([]Event, error) {
 		evs = append(evs, ev)
 	}
 	return evs, nil
+}
+
+// AnalyzeFile loads a newline-delimited JSON trace log and returns the
+// token usage summary. The input text is assumed to be empty.
+func AnalyzeFile(path string) (Summary, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Summary{}, err
+	}
+	defer f.Close()
+	evs, err := ParseLog(f)
+	if err != nil {
+		return Summary{}, err
+	}
+	return Analyze("", evs), nil
 }

--- a/tests/analyze_file_test.go
+++ b/tests/analyze_file_test.go
@@ -1,0 +1,33 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/marcodenic/agentry/internal/trace"
+)
+
+func TestAnalyzeFile(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "log*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmpFile.Close()
+
+	log := `{"type":"step_start","data":{"Content":"hi"}}
+{"type":"final","data":"bye"}`
+	if _, err := tmpFile.WriteString(log); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpFile.Sync(); err != nil {
+		t.Fatal(err)
+	}
+
+	sum, err := trace.AnalyzeFile(tmpFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sum.Tokens != 3 {
+		t.Fatalf("expected 3 tokens got %d", sum.Tokens)
+	}
+}


### PR DESCRIPTION
## Summary
- add table entry for trace analyzer in AGENTS overview
- document how to analyze trace logs in usage guide and README
- mark profiling dashboard complete on the roadmap
- provide AnalyzeFile unit test

## Testing
- `go test ./...` *(fails: Forbidden)*
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a49dd0c40832087336eba2bd9e539