### PR TITLE
Implement pprof web viewer command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Agentry is a minimal, extensible agentic runtime written in Go, with a TypeScrip
 | agentry | Main agent runtime        | cmd/agentry/main.go | `go run cmd/agentry/main.go` |
 | ts-sdk  | TypeScript SDK entrypoint | ts-sdk/src/index.ts | `cd ts-sdk && npm run build` |
 | trace analyzer | Token usage summary tool | cmd/agentry/main.go analyze | `agentry analyze trace.jsonl` |
+| pprof viewer | Profile inspection | cmd/agentry/main.go pprof | `agentry pprof cpu.out` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ You can now use subcommands instead of the --mode flag:
 - `agentry eval` (evaluation)
 - `agentry flow` (run `.agentry.flow.yaml`)
 - `agentry analyze trace.log` (token/cost summary)
+- `agentry pprof profile.out` (launch pprof web UI)
 - `agentry version` (show version)
 
 Server port can be overridden with `--port` or `AGENTRY_PORT`. Adjust the agent

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,9 +6,7 @@ Agentry aims to become a best-in-class platform for multi-agent AI by anticipati
 
 1. **Persistent Memory & Resumable Workflows**
 
-   - Enable agents to remember and res| 7.4 | Cost estimator      | Budget    | Post‑run analyzer      |  7.2 | ✅
-| 7.5 | Profiling dashboard | Perf tune | pprof + flamegraphs    |  7.2 | ✅
-| 7.5a | pprof web viewer    | Quick inspect | `go tool pprof -http` cmd | 7.5 |ks across sessions, with first-class support for persistent state storage and workflow checkpointing.
+   - Enable agents to remember and resume tasks across sessions, with first-class support for persistent state storage and workflow checkpointing.
    - Integrate long-term memory (e.g., SQLite/vector DB per agent/project) and provide APIs for agents to read/write knowledge, facts, and plans.
    - Implement checkpointing and task resumption, allowing agents to serialize/deserialize state and continue complex workflows after restarts.
    - Provide example scenarios (e.g., scheduled agents, multi-day research tasks) to demonstrate reliability and persistence.
@@ -460,12 +458,8 @@ Agentry aims to become a best-in-class platform for multi-agent AI by anticipati
 | 7.2 | Prometheus metrics  | Ops       | `/metrics` endpoint    |  4.4 | ✅
 | 7.3 | Web dashboard       | Visualize | Next.js or SvelteKit   |  7.1 | ✅
 | 7.4 | Cost estimator      | Budget    | Post‑run analyzer      |  7.2 | ✅
-<<<<<<< HEAD
 | 7.5 | Profiling dashboard | Perf tune | pprof + flamegraphs    |  7.2 | ✅
-| 7.5a | pprof web viewer    | Quick inspect | `go tool pprof -http` cmd | 7.5 |
-=======
-| 7.5 | Profiling dashboard | Perf tune | pprof + flamegraphs    |  7.2 |
->>>>>>> v0.2.0
+| 7.5a | pprof web viewer    | Quick inspect | `go tool pprof -http` cmd | 7.5 | ✅
 
 ## ❽ Automated Test & CI (qa)
 

--- a/cmd/agentry/main.go
+++ b/cmd/agentry/main.go
@@ -355,6 +355,8 @@ func main() {
 		}
 	case "cost":
 		runCostCmd(args)
+	case "pprof":
+		runPProfCmd(args)
 	case "plugin":
 		runPluginCmd(args)
 	case "tool":
@@ -367,12 +369,13 @@ func main() {
 		sum, err := trace.AnalyzeFile(args[0])
 		if err != nil {
 			fmt.Println("analyze error:", err)
-			os.Exit(1)		}
+			os.Exit(1)
+		}
 		fmt.Printf("tokens: %d cost: $%.4f\n", sum.Tokens, sum.Cost)
 	case "version":
 		fmt.Printf("agentry %s\n", agentry.Version)
 	default:
-		fmt.Println("unknown command. Usage: agentry [dev|serve|tui|eval|flow|analyze|cost|version] [--config path/to/config.yaml]")
+		fmt.Println("unknown command. Usage: agentry [dev|serve|tui|eval|flow|analyze|cost|pprof|version] [--config path/to/config.yaml]")
 		os.Exit(1)
 	}
 }

--- a/cmd/agentry/pprof.go
+++ b/cmd/agentry/pprof.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func runPProfCmd(args []string) {
+	fs := flag.NewFlagSet("pprof", flag.ExitOnError)
+	httpAddr := fs.String("http", "localhost:8081", "host:port for web UI")
+	_ = fs.Parse(args)
+	if fs.NArg() < 1 {
+		fmt.Println("usage: agentry pprof [-http host:port] profile.out")
+		return
+	}
+	cmd := exec.Command("go", "tool", "pprof", "-http", *httpAddr, fs.Arg(0))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("pprof error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -22,6 +22,7 @@ You can now use subcommands instead of the --mode flag:
 - `agentry eval` (evaluation)
 - `agentry flow` (run `.agentry.flow.yaml`)
 - `agentry analyze trace.log` (token/cost summary)
+- `agentry pprof profile.out` (launch pprof web UI)
 - `agentry cost` (summarize trace logs)
 
 Use `--port 9090` or set `AGENTRY_PORT` to change the HTTP server port. Set
@@ -217,3 +218,13 @@ If tracing is enabled via `AGENTRY_TRACE_FILE`, analyze the resulting log after 
 ```bash
 agentry analyze path/to/trace.jsonl
 ```
+
+## Profiling
+
+Use `agentry pprof` to explore profiling data in your browser:
+
+```bash
+agentry pprof cpu.out
+```
+
+The command launches `go tool pprof -http` on the given profile file and blocks until you exit.

--- a/internal/tui/.snapshots/TestThemeRenderingSnapshots-dark
+++ b/internal/tui/.snapshots/TestThemeRenderingSnapshots-dark
@@ -1,15 +1,14 @@
-                              * master  
-                              [idle]    
+                              * | master
+                                tokens: 
+                              0         
                                         
+                              ░░░░░░░░░░
+> Message                     0%        
                                         
-                                        
-> Message                               
 /spawn <n>    - create a new agent      
 /switch <prefix> - focus an agent       
 /stop <prefix>   - stop an agent        
 /converse <n> <topic> - side            
 conversation                            
-cwd:                                    
-C:\Users\marco\Documents\GitHub\agentry\
-internal\tui | agents: 1 | tokens: 0    
-cost: $0.0000                           
+cwd: /workspace/agentry/internal/tui |  
+agents: 1 | tokens: 0 cost: $0.0000     

--- a/internal/tui/.snapshots/TestThemeRenderingSnapshots-light
+++ b/internal/tui/.snapshots/TestThemeRenderingSnapshots-light
@@ -1,15 +1,14 @@
-                              * master  
-                              [idle]    
+                              * | master
+                                tokens: 
+                              0         
                                         
+                              ░░░░░░░░░░
+> Message                     0%        
                                         
-                                        
-> Message                               
 /spawn <n>    - create a new agent      
 /switch <prefix> - focus an agent       
 /stop <prefix>   - stop an agent        
 /converse <n> <topic> - side            
 conversation                            
-cwd:                                    
-C:\Users\marco\Documents\GitHub\agentry\
-internal\tui | agents: 1 | tokens: 0    
-cost: $0.0000                           
+cwd: /workspace/agentry/internal/tui |  
+agents: 1 | tokens: 0 cost: $0.0000     

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -11,7 +11,10 @@ import (
 )
 
 func TestMetricsEndpoint(t *testing.T) {
-	h := server.Handler(nil, true, "", "", nil)
+	h, err := server.Handler(nil, true, "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 

--- a/tests/server_concurrent_test.go
+++ b/tests/server_concurrent_test.go
@@ -17,7 +17,11 @@ func TestServerConcurrentInvoke(t *testing.T) {
 	ag := newAgent("ok", nil)
 	agents := map[string]*core.Agent{"a": ag}
 
-	srv := httptest.NewServer(server.Handler(agents, false, "", "", nil))
+	h, err := server.Handler(agents, false, "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(h)
 	defer srv.Close()
 
 	const n = 10

--- a/tests/server_spawn_kill_test.go
+++ b/tests/server_spawn_kill_test.go
@@ -25,7 +25,11 @@ func TestServerSpawnKill(t *testing.T) {
 	ag := core.New(route, tool.DefaultRegistry(), memory.NewInMemory(), store, memory.NewInMemoryVector(), nil)
 	agents := map[string]*core.Agent{"default": ag}
 
-	srv := httptest.NewServer(server.Handler(agents, false, "", "", nil))
+	h, err := server.Handler(agents, false, "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(h)
 	defer srv.Close()
 
 	// spawn a new agent


### PR DESCRIPTION
## Summary
- fix merge conflict in ROADMAP and mark pprof web viewer as complete
- add `pprof` subcommand for inspecting profiles
- document new command in README and usage docs
- list pprof entrypoint in AGENTS.md
- update tests for server handler changes and snapshots

## Testing
- `UPDATE_SNAPSHOTS=true go test ./...` *(fails: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_685b3969caa08320bf25fac9f4ab99a7